### PR TITLE
[BUGFIX] Fix memory corruption bug and a potential buffer-overflow bug.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,7 +143,11 @@ file(GLOB_RECURSE FILES_NEED_FORMAT "grape/*.cc"
         "grape/*.h"
         "examples/*.h"
         "examples/*.cc")
-list(FILTER FILES_NEED_FORMAT EXCLUDE REGEX ".*thirdparty.*")
+foreach (file_path ${FILES_NEED_FORMAT})
+    if (${file_path} MATCHES ".*thirdparty.*")
+        list(REMOVE_ITEM FILES_NEED_FORMAT ${file_path})
+    endif ()
+endforeach ()
 
 add_custom_target(clformat
         COMMAND clang-format --style=file -i ${FILES_NEED_FORMAT}

--- a/examples/gnn_sampler/append_only_edgecut_fragment.h
+++ b/examples/gnn_sampler/append_only_edgecut_fragment.h
@@ -454,7 +454,7 @@ class AppendOnlyEdgecutFragment
     }
 
     ivnum_ = vm_ptr_->GetInnerVertexSize(fid_);
-    extra_oe_.resize(ivnum_, -1);
+    extra_oe_.resize(ivnum_ + 1, -1);
     fragment_indices_->Resize(ivnum_);
 
     {

--- a/examples/gnn_sampler/append_only_edgecut_fragment.h
+++ b/examples/gnn_sampler/append_only_edgecut_fragment.h
@@ -391,7 +391,7 @@ class AppendOnlyEdgecutFragment
 
     extra_oenum_ = 0;
     extra_oe_.clear();
-    extra_oe_.resize(ivnum_ + 1, -1);
+    extra_oe_.resize(ivnum_, -1);
 
     ivdata_.clear();
     ivdata_.resize(ivnum_);
@@ -454,7 +454,7 @@ class AppendOnlyEdgecutFragment
     }
 
     ivnum_ = vm_ptr_->GetInnerVertexSize(fid_);
-    extra_oe_.resize(ivnum_ + 1, -1);
+    extra_oe_.resize(ivnum_, -1);
     fragment_indices_->Resize(ivnum_);
 
     {
@@ -621,7 +621,7 @@ class AppendOnlyEdgecutFragment
     min_old_olid_ = id_mask_ - ovnum_;
     extra_oenum_ = 0;
     extra_oe_.clear();
-    extra_oe_.resize(ivnum_ + 1, -1);
+    extra_oe_.resize(ivnum_, -1);
   }
 
   void PrepareToRunApp(MessageStrategy strategy,

--- a/examples/gnn_sampler/kafka_consumer.h
+++ b/examples/gnn_sampler/kafka_consumer.h
@@ -78,7 +78,7 @@ class KafkaConsumer {
       RdKafka::TopicPartition* topic_partition =
           RdKafka::TopicPartition::create(topic_, i);
       consumer_ptrs_[i]->assign({topic_partition});
-      free(topic_partition);
+      delete topic_partition;
       topic_partition = nullptr;
       consumer_ptrs_[i]->subscribe({topic_});
 
@@ -91,6 +91,7 @@ class KafkaConsumer {
       qmq_[i]->SetProducerNum(1);
       emq_[i]->SetProducerNum(1);
     }
+    delete conf;  // release the memory resource
 
     startFetch();
   }

--- a/examples/gnn_sampler/kafka_producer.h
+++ b/examples/gnn_sampler/kafka_producer.h
@@ -59,6 +59,7 @@ class KafkaProducer {
     if (!producer_) {
       LOG(ERROR) << "Failed to create kafka producer: " << rdkafka_err;
     }
+    delete conf;  // release the memory resource
   }
 
   ~KafkaProducer() = default;

--- a/grape/utils/gcontainer.h
+++ b/grape/utils/gcontainer.h
@@ -294,7 +294,7 @@ class Array {
       pointer __old_begin = this->__base.__begin_;
       pointer __old_end = this->__base.__end_;
       __vallocate(__new_size);
-      __construct_at_end(__old_begin, __old_end, __new_size);
+      __construct_at_end(__old_begin, __old_begin + __new_size, __new_size);
 
       __destruct_at_end(__old_begin, __old_end);
       __vdeallocate(__old_begin, __old_size);
@@ -316,7 +316,7 @@ class Array {
       pointer __old_begin = this->__base.__begin_;
       pointer __old_end = this->__base.__end_;
       __vallocate(__new_size);
-      __construct_at_end(__old_begin, __old_end, __new_size);
+      __construct_at_end(__old_begin, __old_begin + __new_size, __new_size);
 
       __destruct_at_end(__old_begin, __old_end);
       __vdeallocate(__old_begin, __old_size);


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/libgrape-lite/blob/master/CONTRIBUTING.rst before opening an issue.
-->

## What do these changes do?

This pr fixes the memory corruption in gnn_sampler (specifically, in `KafkaConsumer`), where a `delete` should be used, rather than a `free()`.

This pr also:

+ Enhance the kafka part with an extra `delete conf;` to release the memory resource that won't be used anymore
+ Fixed a potential heap-buffer-overflow bug in `GArray`'s resize, when the new size is smaller than the old size.
+ Fixed a bug `append_only_edgecut_fragment.h`, which leads to the `extra_oe_` being copied every time we extend the fragment.
+ Enhance the support for lower version of CMake (i.e., cmake < 3.6) where the `list(FILTER) syntax` is invalid. 