### PR TITLE
[BUGFIX-15] Fix infinite iterations in pagerank when max_round<=0

### DIFF
--- a/examples/analytical_apps/pagerank/pagerank.h
+++ b/examples/analytical_apps/pagerank/pagerank.h
@@ -51,6 +51,8 @@ class PageRank
 
   void PEval(const fragment_t& frag, context_t& ctx,
              message_manager_t& messages) {
+    if (ctx.max_round <= 0) { return; }
+
     auto inner_vertices = frag.InnerVertices();
 
 #ifdef PROFILING


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/libgrape-lite/blob/master/CONTRIBUTING.rst before opening an issue.
-->

## What do these changes do?
Fix infinite iterations in pagerank algo when max_round <= 0
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #15 
