### PR TITLE
The LIBGRAPELITE_HOME should be pointed to where it locates.

### DIFF
--- a/libgrapelite-config.in.cmake
+++ b/libgrapelite-config.in.cmake
@@ -6,8 +6,9 @@
 #  LIBGRAPELITE_INCLUDE_DIRS        - include directories for libgrape-lite
 #  LIBGRAPELITE_LIBRARIES           - libraries to link against
 
+set(LIBGRAPELITE_HOME "${CMAKE_CURRENT_LIST_DIR}/../../..")
 include("${CMAKE_CURRENT_LIST_DIR}/libgrapelite-targets.cmake")
 
 set(LIBGRAPELITE_LIBRARIES grape-lite)
-set(LIBGRAPELITE_INCLUDE_DIR "@CMAKE_INSTALL_PREFIX@/include")
+set(LIBGRAPELITE_INCLUDE_DIR "${LIBGRAPELITE_HOME}/include")
 set(LIBGRAPELITE_INCLUDE_DIRS "${LIBGRAPELITE_INCLUDE_DIR}")


### PR DESCRIPTION
rather than the hard absolute path where it placed during installation.