### PR TITLE
add set_{fid, fnum} methods to CommSpec 

### DIFF
--- a/grape/worker/comm_spec.h
+++ b/grape/worker/comm_spec.h
@@ -131,6 +131,10 @@ class CommSpec {
 
   inline fid_t fid() const { return fid_; }
 
+  inline void set_fnum(fid_t fnum) { fnum_ = fnum; }
+
+  inline void set_fid(fid_t fid) { fid_ = fid; }
+
   __attribute__((no_sanitize_address)) inline MPI_Comm comm() const {
     return comm_;
   }


### PR DESCRIPTION

## What do these changes do?
add `set_fid`, `set_fnum` to CommSpec to support GraphScope Dynamic fragment load duplicated (whole) graph in every worker.

## Related issue number
https://github.com/alibaba/GraphScope/issues/317

## related pull request
https://github.com/alibaba/GraphScope/pull/325
