### PR TITLE
Add a method to init global vertex map with fnum

### DIFF
--- a/grape/vertex_map/global_vertex_map.h
+++ b/grape/vertex_map/global_vertex_map.h
@@ -142,6 +142,8 @@ class GlobalVertexMap : public VertexMapBase<OID_T, VID_T> {
     int worker_id = comm_spec.worker_id();
     int worker_num = comm_spec.worker_num();
     bool to_sort = false;
+    // worker num has to be equal to fnum when constructing vertex map.
+    CHECK(worker_num == static_cast<int>(comm_spec.fnum()));
     for (fid_t fid = 0; fid != comm_spec.fnum(); ++fid) {
       if (!l2o_[fid].empty()) {
         to_sort = o2l_[fid].empty();

--- a/grape/vertex_map/global_vertex_map.h
+++ b/grape/vertex_map/global_vertex_map.h
@@ -60,6 +60,12 @@ class GlobalVertexMap : public VertexMapBase<OID_T, VID_T> {
     l2o_.resize(Base::GetCommSpec().fnum());
   }
 
+  void Init(fid_t fnum) {
+    Base::Init(fnum);
+    o2l_.resize(fnum);
+    l2o_.resize(fnum);
+  }
+
   size_t GetTotalVertexSize() {
     size_t size = 0;
     for (const auto& v : o2l_) {

--- a/grape/vertex_map/vertex_map_base.h
+++ b/grape/vertex_map/vertex_map_base.h
@@ -64,18 +64,12 @@ class VertexMapBase {
 
   virtual void Init() {
     fnum_ = comm_spec_.fnum();
-    fid_t maxfid = fnum_ - 1;
-    if (maxfid == 0) {
-      fid_offset_ = (sizeof(VID_T) * 8) - 1;
-    } else {
-      int i = 0;
-      while (maxfid) {
-        maxfid >>= 1;
-        ++i;
-      }
-      fid_offset_ = (sizeof(VID_T) * 8) - i;
-    }
-    id_mask_ = ((VID_T) 1 << fid_offset_) - (VID_T) 1;
+    initOffsetAndMask();
+  }
+
+  virtual void Init(fid_t fnum) {
+    fnum_ = fnum;
+    initOffsetAndMask();
   }
 
   fid_t GetFragmentNum() const { return fnum_; }
@@ -106,6 +100,22 @@ class VertexMapBase {
   }
 
   int GetFidOffset() const { return fid_offset_; }
+
+ private:
+  inline void initOffsetAndMask() {
+    fid_t maxfid = fnum_ - 1;
+    if (maxfid == 0) {
+      fid_offset_ = (sizeof(VID_T) * 8) - 1;
+    } else {
+      int i = 0;
+      while (maxfid) {
+        maxfid >>= 1;
+        ++i;
+      }
+      fid_offset_ = (sizeof(VID_T) * 8) - i;
+    }
+    id_mask_ = ((VID_T) 1 << fid_offset_) - (VID_T) 1;
+  }
 
  protected:
   fid_t fnum_;


### PR DESCRIPTION

## What do these changes do?
add a method to init global vertex map with fnum to  support GraphScope DynamicFragmentVertexMap load duplicated (whole) graph in every worker.

## Related issue number
https://github.com/alibaba/GraphScope/issues/317

Fixes
https://github.com/alibaba/GraphScope/pull/325
