### PR TITLE
Fix warning in flat_hash_map under certain compilers

### DIFF
--- a/thirdparty/flat_hash_map/flat_hash_map.hpp
+++ b/thirdparty/flat_hash_map/flat_hash_map.hpp
@@ -874,6 +874,9 @@ public:
             return std::addressof(current->value);
         }
 
+        // the template automatically disables the operator when value_type is already
+        // const, because that would cause a lot of compiler warnings otherwise.
+        template<class target_type = const value_type, class = typename std::enable_if<std::is_same<target_type, const value_type>::value && !std::is_same<target_type, value_type>::value>::type>
         operator templated_iterator<const value_type>() const
         {
             return { current };


### PR DESCRIPTION
I found under certain compilers, like NVCC, when compiling libgrape-lite using that, the following warning will be reported.

```
/tmp/tmp.oOqUdB4akj/thirdparty/libgrape-lite/thirdparty/flat_hash_map/flat_hash_map.hpp(877): warning: "ska::detailv3::sherwood_v3_table<T, FindKey, ArgumentHash, Hasher, ArgumentEqual, Equal, ArgumentAlloc, EntryAlloc>::templated_iterator<ValueType>::operator ska::detailv3::sherwood_v3_table<std::pair<int64_t, grape::fid_t>, int64_t, std::hash<long>, ska::detailv3::KeyOrValueHasher<int64_t, std::pair<int64_t, grape::fid_t>, std::hash<long>>, std::equal_to<int64_t>, ska::detailv3::KeyOrValueEquality<int64_t, std::pair<int64_t, grape::fid_t>, std::equal_to<int64_t>>, std::allocator<std::pair<int64_t, grape::fid_t>>, std::allocator<ska::detailv3::sherwood_v3_entry<std::pair<int64_t, grape::fid_t>>>>::templated_iterator<const std::pair<int64_t, grape::fid_t>>() const [with T=std::pair<int64_t, grape::fid_t>, FindKey=int64_t, ArgumentHash=std::hash<long>, Hasher=ska::detailv3::KeyOrValueHasher<int64_t, std::pair<int64_t, grape::fid_t>, std::hash<long>>, ArgumentEqual=std::equal_to<int64_t>, Equal=ska::detailv3::KeyOrValueEquality<int64_t, std::pair<int64_t, grape::fid_t>, std::equal_to<int64_t>>, ArgumentAlloc=std::allocator<std::pair<int64_t, grape::fid_t>>, EntryAlloc=std::allocator<ska::detailv3::sherwood_v3_entry<std::pair<int64_t, grape::fid_t>>>, ValueType=const std::pair<int64_t, grape::fid_t>]" will not be called for implicit or explicit conversions
          detected during:
            instantiation of class "ska::detailv3::sherwood_v3_table<T, FindKey, ArgumentHash, Hasher, ArgumentEqual, Equal, ArgumentAlloc, EntryAlloc>::templated_iterator<ValueType> [with T=std::pair<int64_t, grape::fid_t>, FindKey=int64_t, ArgumentHash=std::hash<long>, Hasher=ska::detailv3::KeyOrValueHasher<int64_t, std::pair<int64_t, grape::fid_t>, std::hash<long>>, ArgumentEqual=std::equal_to<int64_t>, Equal=ska::detailv3::KeyOrValueEquality<int64_t, std::pair<int64_t, grape::fid_t>, std::equal_to<int64_t>>, ArgumentAlloc=std::allocator<std::pair<int64_t, grape::fid_t>>, EntryAlloc=std::allocator<ska::detailv3::sherwood_v3_entry<std::pair<int64_t, grape::fid_t>>>, ValueType=const std::pair<int64_t, grape::fid_t>]" 
/tmp/tmp.oOqUdB4akj/thirdparty/libgrape-lite/grape/vertex_map/global_vertex_map.h(88): here
            instantiation of "__nv_bool grape::GlobalVertexMap<OID_T, VID_T>::AddVertex(grape::fid_t, const OID_T &, VID_T &) [with OID_T=int64_t, VID_T=uint32_t]" 
/tmp/tmp.oOqUdB4akj/thirdparty/libgrape-lite/grape/vertex_map/global_vertex_map.h(55): here
            instantiation of class "grape::GlobalVertexMap<OID_T, VID_T> [with OID_T=int64_t, VID_T=uint32_t]" 
/tmp/tmp.oOqUdB4akj/thirdparty/libgrape-lite/grape/vertex_map/global_vertex_map.h(55): here
            instantiation of "grape::GlobalVertexMap<OID_T, VID_T>::GlobalVertexMap(const grape::CommSpec &) [with OID_T=int64_t, VID_T=uint32_t]" 
/tmp/tmp.oOqUdB4akj/grape_gpu/fragment/basic_fragment_loader.h(511): here
            instantiation of "grape_gpu::BasicFragmentLoader<FRAG_T, PARTITIONER_T, IOADAPTOR_T, std::enable_if<std::is_same<FRAG_T::vdata_t, grape::EmptyType>::value, void>::type>::BasicFragmentLoader(const grape::CommSpec &) [with FRAG_T=grape_gpu::HostFragment<int64_t, uint32_t, grape::EmptyType, uint32_t, grape::LoadStrategy::kOnlyOut>, PARTITIONER_T=grape::SegmentedPartitioner<int64_t>, IOADAPTOR_T=grape::LocalIOAdaptor]" 
/tmp/tmp.oOqUdB4akj/grape_gpu/fragment/e_fragment_loader.h(68): here
            instantiation of "grape_gpu::EFragmentLoader<FRAG_T, PARTITIONER_T, IOADAPTOR_T, LINE_PARSER_T>::EFragmentLoader(const grape::CommSpec &) [with FRAG_T=grape_gpu::HostFragment<int64_t, uint32_t, grape::EmptyType, uint32_t, grape::LoadStrategy::kOnlyOut>, PARTITIONER_T=grape::SegmentedPartitioner<int64_t>, IOADAPTOR_T=grape::LocalIOAdaptor, LINE_PARSER_T=grape::TSVLineParser<signed long, grape::EmptyType, unsigned int>]" 
/tmp/tmp.oOqUdB4akj/grape_gpu/fragment/loader.h(98): here
            instantiation of "std::shared_ptr<FRAG_T> grape_gpu::LoadGraph<FRAG_T,PARTITIONER_T,IOADAPTOR_T,LINE_PARSER_T>(const std::string &, const std::string &, const grape::CommSpec &, const std::string &, grape_gpu::LoadGraphSpec) [with FRAG_T=grape_gpu::HostFragment<int64_t, uint32_t, grape::EmptyType, uint32_t, grape::LoadStrategy::kOnlyOut>, PARTITIONER_T=grape::SegmentedPartitioner<int64_t>, IOADAPTOR_T=grape::LocalIOAdaptor, LINE_PARSER_T=grape::TSVLineParser<signed long, grape::EmptyType, unsigned int>]" 
/tmp/tmp.oOqUdB4akj/examples/sampler/run_sampler.h(85): here
            instantiation of "void grape_gpu::CreateAndQuery<FRAG_T,APP_T,Args...>(const grape::CommSpec &, const std::string &, const std::string &, const std::string &, Args...) [with FRAG_T=grape_gpu::HostFragment<int64_t, uint32_t, grape::EmptyType, uint32_t, grape::LoadStrategy::kOnlyOut>, APP_T=grape_gpu::COOBased<grape_gpu::HostFragment<int64_t, uint32_t, grape::EmptyType, uint32_t, grape::LoadStrategy::kOnlyOut>>, Args=<google::int32, fLS::clstring>]" 
/tmp/tmp.oOqUdB4akj/examples/sampler/run_sampler.h(156): here
            instantiation of "void grape_gpu::Run<OID_T,VID_T,VDATA_T,EDATA_T>() [with OID_T=int64_t, VID_T=uint32_t, VDATA_T=grape::EmptyType, EDATA_T=uint32_t]" 
/tmp/tmp.oOqUdB4akj/examples/sampler/run_sampler.cu(40): here
```

This issue is also mentioned in another GitHub issue, https://github.com/pytorch/pytorch/pull/17562
In most compilers, this problem will not occur. But I want to fix it because I don't want to see these warnings when I'm using libgrape-lite with CUDA. So, I just introduce that change https://github.com/pytorch/pytorch/pull/17562/files into our codebase. I think this change will not bring any side effects.