### PR TITLE
Fix string parser bug

### DIFF
--- a/grape/io/line_parser_base.h
+++ b/grape/io/line_parser_base.h
@@ -119,15 +119,16 @@ inline const char* match<long double>(char const* str, long double& r,
 
 template <>
 inline const char* match<std::string>(char const* str, std::string& r,
-                                      char const* end) {
+                                      char const*) {
   int nlen1 = 0, nlen2 = 0;
-  while (str + nlen1 != end && str[nlen1] &&
-         (str[nlen1] == ' ' || str[nlen1] == '\t')) {
+  // skip preceding spaces or new line mark
+  while (str[nlen1] &&
+         (str[nlen1] == '\n' || str[nlen1] == ' ' || str[nlen1] == '\t')) {
     nlen1 += 1;
   }
   nlen2 = nlen1;
-  while (str + nlen2 != end && str[nlen2] &&
-         (str[nlen2] != ' ' && str[nlen2] != '\t')) {
+  while (str[nlen2] &&
+         (str[nlen2] != '\n' && str[nlen2] != ' ' && str[nlen2] != '\t')) {
     nlen2 += 1;
   }
   r = std::string(str + nlen1, nlen2 - nlen1);

--- a/grape/io/line_parser_base.h
+++ b/grape/io/line_parser_base.h
@@ -119,7 +119,7 @@ inline const char* match<long double>(char const* str, long double& r,
 
 template <>
 inline const char* match<std::string>(char const* str, std::string& r,
-                                      char const*) {
+                                      char const* end) {
   int nlen1 = 0, nlen2 = 0;
   // skip preceding spaces or new line mark
   while (str + nlen1 != end && str[nlen1] &&

--- a/grape/io/line_parser_base.h
+++ b/grape/io/line_parser_base.h
@@ -122,12 +122,12 @@ inline const char* match<std::string>(char const* str, std::string& r,
                                       char const*) {
   int nlen1 = 0, nlen2 = 0;
   // skip preceding spaces or new line mark
-  while (str[nlen1] &&
+  while (str + nlen1 != end && str[nlen1] &&
          (str[nlen1] == '\n' || str[nlen1] == ' ' || str[nlen1] == '\t')) {
     nlen1 += 1;
   }
   nlen2 = nlen1;
-  while (str[nlen2] &&
+  while (str + nlen2 != end && str[nlen2] &&
          (str[nlen2] != '\n' && str[nlen2] != ' ' && str[nlen2] != '\t')) {
     nlen2 += 1;
   }

--- a/grape/io/tsv_line_parser.h
+++ b/grape/io/tsv_line_parser.h
@@ -51,7 +51,6 @@ class TSVLineParser : public LineParserBase<OID_T, VDATA_T, EDATA_T> {
   template <typename... Ts>
   inline const char* LineParserForEverything(const std::string& line,
                                              Ts&... vals) {
-    std::cmatch matches;
     return this->LineParserForEverything(
         line.c_str(),
         std::forward<typename std::add_lvalue_reference<Ts>::type>(vals)...);


### PR DESCRIPTION
The current implementation does not eat the new line character - `\n`, so if there's a line `123\n`, the variable `std::string r` will contain a '\n'.