### PR TITLE
Add thread pool and use in ParallelEngine & Bitset

### DIFF
--- a/examples/analytical_apps/bfs/bfs.h
+++ b/examples/analytical_apps/bfs/bfs.h
@@ -56,8 +56,8 @@ class BFS : public ParallelAppBase<FRAG_T, BFSContext<FRAG_T>>,
     auto outer_vertices = frag.OuterVertices();
 
     // init double buffer which contains updated vertices using bitmap
-    ctx.curr_inner_updated.Init(inner_vertices, thread_num());
-    ctx.next_inner_updated.Init(inner_vertices, thread_num());
+    ctx.curr_inner_updated.Init(inner_vertices, &GetThreadPool());
+    ctx.next_inner_updated.Init(inner_vertices, &GetThreadPool());
 
 #ifdef PROFILING
     ctx.exec_time -= GetCurrentTime();
@@ -102,7 +102,7 @@ class BFS : public ParallelAppBase<FRAG_T, BFSContext<FRAG_T>>,
 
     depth_type next_depth = ctx.current_depth + 1;
     int thrd_num = thread_num();
-    ctx.next_inner_updated.ParallelClear(thrd_num);
+    ctx.next_inner_updated.ParallelClear(&GetThreadPool());
 
 #ifdef PROFILING
     ctx.preprocess_time -= GetCurrentTime();
@@ -127,7 +127,7 @@ class BFS : public ParallelAppBase<FRAG_T, BFSContext<FRAG_T>>,
     if (ctx.avg_degree > 10) {
       auto ivnum = frag.GetInnerVerticesNum();
       rate = static_cast<double>(
-                 ctx.curr_inner_updated.ParallelCount(thread_num())) /
+                 ctx.curr_inner_updated.ParallelCount(&GetThreadPool())) /
              static_cast<double>(ivnum);
       if (rate > 0.1) {
         auto inner_vertices = frag.InnerVertices();

--- a/examples/analytical_apps/sssp/sssp.h
+++ b/examples/analytical_apps/sssp/sssp.h
@@ -60,7 +60,7 @@ class SSSP : public ParallelAppBase<FRAG_T, SSSPContext<FRAG_T>>,
     ctx.exec_time -= GetCurrentTime();
 #endif
 
-    ctx.next_modified.ParallelClear(thread_num());
+    ctx.next_modified.ParallelClear(&GetThreadPool());
 
     // Get the channel. Messages assigned to this channel will be sent by the
     // message manager in parallel with the evaluation process.
@@ -113,7 +113,7 @@ class SSSP : public ParallelAppBase<FRAG_T, SSSPContext<FRAG_T>>,
     ctx.preprocess_time -= GetCurrentTime();
 #endif
 
-    ctx.next_modified.ParallelClear(thread_num());
+    ctx.next_modified.ParallelClear(&GetThreadPool());
 
     // parallel process and reduce the received messages
     messages.ParallelProcess<fragment_t, double>(

--- a/examples/analytical_apps/wcc/wcc.h
+++ b/examples/analytical_apps/wcc/wcc.h
@@ -150,7 +150,7 @@ class WCC : public ParallelAppBase<FRAG_T, WCCContext<FRAG_T>>,
                message_manager_t& messages) {
     using vid_t = typename context_t::vid_t;
 
-    ctx.next_modified.ParallelClear(thread_num());
+    ctx.next_modified.ParallelClear(&GetThreadPool());
 
 #ifdef PROFILING
     ctx.preprocess_time -= GetCurrentTime();
@@ -171,7 +171,7 @@ class WCC : public ParallelAppBase<FRAG_T, WCCContext<FRAG_T>>,
 
     vid_t ivnum = frag.GetInnerVerticesNum();
     double rate = static_cast<double>(ctx.curr_modified.ParallelPartialCount(
-                      thread_num(), 0, ivnum)) /
+                      &GetThreadPool(), 0, ivnum)) /
                   static_cast<double>(ivnum);
     // If active vertices are few, pushing will be used.
     if (rate > 0.1) {

--- a/grape/utils/bitset.h
+++ b/grape/utils/bitset.h
@@ -21,6 +21,8 @@ limitations under the License.
 #include <algorithm>
 #include <utility>
 
+#include "thread_pool.h"
+
 #define WORD_SIZE(n) (((n) + 63ul) >> 6)
 
 #define WORD_INDEX(i) ((i) >> 6)
@@ -64,11 +66,21 @@ class Bitset {
     }
   }
 
-  void parallel_clear(int thread_num) {
-#pragma omp parallel for num_threads(thread_num)
-    for (size_t i = 0; i < size_in_words_; ++i) {
-      data_[i] = 0;
+  void parallel_clear(ThreadPool* thread_pool) {
+    uint32_t thread_num = thread_pool->GetThreadNum();
+    size_t chunk_size =
+        std::max(1024ul, (size_in_words_ + thread_num - 1) / thread_num);
+    size_t thread_begin = 0, thread_end = std::min(chunk_size, size_in_words_);
+    std::vector<std::future<void>> results(thread_num);
+    for (uint32_t tid = 0; tid < thread_num; ++tid) {
+      results[tid] = thread_pool->enqueue([thread_begin, thread_end, this]() {
+        for (size_t i = thread_begin; i < thread_end; ++i)
+          data_[i] = 0;
+      });
+      thread_begin = thread_end;
+      thread_end = std::min(thread_end + chunk_size, size_in_words_);
     }
+    thread_pool->WaitEnd(results);
   }
 
   bool empty() const {
@@ -146,12 +158,25 @@ class Bitset {
     return ret;
   }
 
-  size_t parallel_count(int thread_num) const {
+  size_t parallel_count(ThreadPool* thread_pool) const {
     size_t ret = 0;
-#pragma omp parallel for num_threads(thread_num) reduction(+ : ret)
-    for (size_t i = 0; i < size_in_words_; ++i) {
-      ret += __builtin_popcountll(data_[i]);
+    uint32_t thread_num = thread_pool->GetThreadNum();
+    size_t chunk_size =
+        std::max(1024ul, (size_in_words_ + thread_num - 1) / thread_num);
+    size_t thread_start = 0, thread_end = std::min(chunk_size, size_in_words_);
+    std::vector<std::future<void>> results(thread_num);
+    for (uint32_t tid = 0; tid < thread_num; ++tid) {
+      results[tid] =
+          thread_pool->enqueue([thread_start, thread_end, this, tid, &ret]() {
+            size_t ret_t = 0;
+            for (size_t i = thread_start; i < thread_end; ++i)
+              ret_t += __builtin_popcountll(data_[i]);
+            __sync_fetch_and_add(&ret, ret_t);
+          });
+      thread_start = thread_end;
+      thread_end = std::min(thread_end + chunk_size, size_in_words_);
     }
+    thread_pool->WaitEnd(results);
     return ret;
   }
 
@@ -177,17 +202,31 @@ class Bitset {
     return ret;
   }
 
-  size_t parallel_partial_count(int thread_num, size_t begin,
+  size_t parallel_partial_count(ThreadPool* thread_pool, size_t begin,
                                 size_t end) const {
     size_t ret = 0;
     size_t cont_beg = ROUND_UP(begin);
     size_t cont_end = ROUND_DOWN(end);
     size_t word_beg = WORD_INDEX(cont_beg);
     size_t word_end = WORD_INDEX(cont_end);
-#pragma omp parallel for num_threads(thread_num) reduction(+ : ret)
-    for (size_t i = word_beg; i < word_end; ++i) {
-      ret += __builtin_popcountll(data_[i]);
+    uint32_t thread_num = thread_pool->GetThreadNum();
+    size_t chunk_size =
+        std::max(1024ul, (word_end - word_beg + thread_num - 1) / thread_num);
+    size_t thread_begin = word_beg,
+           thread_end = std::min(word_beg + chunk_size, word_end);
+    std::vector<std::future<void>> results(thread_num);
+    for (uint32_t tid = 0; tid < thread_num; ++tid) {
+      results[tid] =
+          thread_pool->enqueue([thread_begin, thread_end, this, tid, &ret]() {
+            size_t ret_t = 0;
+            for (size_t i = thread_begin; i < thread_end; ++i)
+              ret_t += __builtin_popcountll(data_[i]);
+            __sync_fetch_and_add(&ret, ret_t);
+          });
+      thread_begin = thread_end;
+      thread_end = std::min(thread_end + chunk_size, word_end);
     }
+    thread_pool->WaitEnd(results);
     if (cont_beg != begin) {
       uint64_t first_word = data_[WORD_INDEX(begin)];
       first_word = (first_word >> (64 - (cont_beg - begin)));

--- a/grape/utils/thread_pool.h
+++ b/grape/utils/thread_pool.h
@@ -1,0 +1,131 @@
+/** Credits to Jakob Progsch (@progschj)
+ https://github.com/progschj/ThreadPool
+ 
+ Copyright (c) 2012 Jakob Progsch, Václav Zeman
+ 
+ This software is provided 'as-is', without any express or implied
+ warranty. In no event will the authors be held liable for any damages
+ arising from the use of this software.
+ 
+ Permission is granted to anyone to use this software for any purpose,
+ including commercial applications, and to alter it and redistribute it
+ freely, subject to the following restrictions:
+ 
+ 1. The origin of this software must not be misrepresented; you must not
+ claim that you wrote the original software. If you use this software
+ in a product, an acknowledgment in the product documentation would be
+ appreciated but is not required.
+ 
+ 2. Altered source versions must be plainly marked as such, and must not be
+ misrepresented as being the original software.
+ 
+ 3. This notice may not be removed or altered from any source
+ distribution.
+ 
+ Modified by 2020 Alibaba Group to use in this project
+*/
+
+#ifndef GRAPE_UTILS_THREAD_POOL_H_
+#define GRAPE_UTILS_THREAD_POOL_H_
+
+#include <condition_variable>
+#include <functional>
+#include <future>
+#include <memory>
+#include <mutex>
+#include <queue>
+#include <stdexcept>
+#include <thread>
+#include <vector>
+
+class ThreadPool {
+ public:
+  ThreadPool(ThreadPool const&) = delete;
+  ThreadPool& operator=(ThreadPool const&) = delete;
+  ThreadPool() {}
+  inline void InitThreadPool(size_t);
+
+  template <class F, class... Args>
+  auto enqueue(F&& f, Args&&... args)
+      -> std::future<typename std::result_of<F(Args...)>::type>;
+  inline int GetThreadNum() { return thread_num_; }
+  void WaitEnd(std::vector<std::future<void>>& results);
+  ~ThreadPool();
+
+ private:
+  // need to keep track of threads so we can join them
+  std::vector<std::thread> workers;
+  // the task queue
+  std::queue<std::function<void()>> tasks;
+
+  // synchronization
+  std::mutex queue_mutex;
+  std::condition_variable condition;
+  bool stop{false};
+  size_t thread_num_{1};
+};
+
+// the constructor just launches some amount of workers
+inline void ThreadPool::InitThreadPool(size_t threads) {
+  thread_num_ = threads;
+  for (size_t i = 0; i < threads; ++i)
+    workers.emplace_back([this] {
+      for (;;) {
+        std::function<void()> task;
+
+        {
+          std::unique_lock<std::mutex> lock(this->queue_mutex);
+          this->condition.wait(
+              lock, [this] { return this->stop || !this->tasks.empty(); });
+          if (this->stop && this->tasks.empty())
+            return;
+          task = std::move(this->tasks.front());
+          this->tasks.pop();
+        }
+
+        task();
+      }
+    });
+}
+
+// use to wait for all tasks end
+inline void ThreadPool::WaitEnd(std::vector<std::future<void>>& results) {
+  for (size_t tid = 0; tid < thread_num_; ++tid)
+    results[tid].get();
+}
+
+// add new task to the pool
+template <class F, class... Args>
+auto ThreadPool::enqueue(F&& f, Args&&... args)
+    -> std::future<typename std::result_of<F(Args...)>::type> {
+  using return_type = typename std::result_of<F(Args...)>::type;
+
+  auto task = std::make_shared<std::packaged_task<return_type()>>(
+      std::bind(std::forward<F>(f), std::forward<Args>(args)...));
+
+  std::future<return_type> res = task->get_future();
+  {
+    std::unique_lock<std::mutex> lock(queue_mutex);
+
+    // don't allow enqueueing after stopping the pool
+    if (stop)
+      throw std::runtime_error("enqueue on stopped ThreadPool");
+
+    tasks.emplace([task]() { (*task)(); });
+  }
+  condition.notify_one();
+  return res;
+}
+
+// the destructor joins all threads
+inline ThreadPool::~ThreadPool() {
+  {
+    std::unique_lock<std::mutex> lock(queue_mutex);
+    stop = true;
+  }
+  condition.notify_all();
+  for (std::thread& worker : workers)
+    worker.join();
+}
+
+#endif  // GRAPE_UTILS_THREAD_POOL_H_

--- a/grape/utils/vertex_set.h
+++ b/grape/utils/vertex_set.h
@@ -19,6 +19,7 @@ limitations under the License.
 #include <utility>
 
 #include "grape/utils/bitset.h"
+#include "grape/utils/thread_pool.h"
 #include "grape/utils/vertex_array.h"
 
 namespace grape {
@@ -39,27 +40,29 @@ class DenseVertexSet {
 
   ~DenseVertexSet() = default;
 
-  void Init(const VertexRange<VID_T>& range, int thread_num = 1) {
+  void Init(const VertexRange<VID_T>& range,
+            ThreadPool* thread_pool = nullptr) {
     beg_ = range.begin().GetValue();
     end_ = range.end().GetValue();
     bs_.init(end_ - beg_);
-    if (thread_num == 1) {
+    if (thread_pool == nullptr) {
       bs_.clear();
     } else {
-      bs_.parallel_clear(thread_num);
+      bs_.parallel_clear(thread_pool);
     }
   }
 
-  void Init(const VertexVector<VID_T>& vertices, int thread_num = 1) {
+  void Init(const VertexVector<VID_T>& vertices,
+            ThreadPool* thread_pool = nullptr) {
     if (vertices.size() == 0)
       return;
     beg_ = vertices[0].GetValue();
     end_ = vertices[vertices.size() - 1].GetValue();
     bs_.init(end_ - beg_ + 1);
-    if (thread_num == 1) {
+    if (thread_pool == nullptr) {
       bs_.clear();
     } else {
-      bs_.parallel_clear(thread_num);
+      bs_.parallel_clear(thread_pool);
     }
   }
 
@@ -81,21 +84,24 @@ class DenseVertexSet {
 
   size_t Count() const { return bs_.count(); }
 
-  size_t ParallelCount(int thread_num) const {
-    return bs_.parallel_count(thread_num);
+  size_t ParallelCount(ThreadPool* thread_pool) const {
+    return bs_.parallel_count(thread_pool);
   }
 
   size_t PartialCount(VID_T beg, VID_T end) const {
     return bs_.partial_count(beg - beg_, end - beg_);
   }
 
-  size_t ParallelPartialCount(int thread_num, VID_T beg, VID_T end) const {
-    return bs_.parallel_partial_count(thread_num, beg - beg_, end - beg_);
+  size_t ParallelPartialCount(ThreadPool* thread_pool, VID_T beg,
+                              VID_T end) const {
+    return bs_.parallel_partial_count(thread_pool, beg - beg_, end - beg_);
   }
 
   void Clear() { bs_.clear(); }
 
-  void ParallelClear(int thread_num) { bs_.parallel_clear(thread_num); }
+  void ParallelClear(ThreadPool* thread_pool) {
+    bs_.parallel_clear(thread_pool);
+  }
 
   void Swap(DenseVertexSet<VID_T>& rhs) {
     std::swap(beg_, rhs.beg_);


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/libgrape-lite/blob/master/CONTRIBUTING.rst before opening an issue.
-->

## What do these changes do?
1. add a ThreadPool class member to ParallelEngine for support of thread reuse in ForEach functions.
2. delivery the ThreadPool to BitSet for support of parallel functions which are previously implemented with openmp.

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

None
