### PR TITLE
Add thread pool and use in ParallelEngine & Bitset

### DIFF
--- a/Performance.md
+++ b/Performance.md
@@ -18,36 +18,36 @@ We made minor changes on their code and datasets:
 The results are reported below. The numbers in the table represent the evaluation time in seconds. 
 The best results are marked in **bold**.
 
-| Algorithm |     Dataset    |      PowerGraph     |     GeminiGraph     |      Plato      |     libgrape-lite     |
-|-----------|----------------|---------------------|---------------------|-----------------|-----------------------|
-|    SSSP   | datagen-9_0-fb |        6.48         |        0.74         |  N/A  |        **0.52**           |
-|           | datagen-9_1-fb |        7.14         |        0.99         |  N/A  |        **0.62**           |
-|           | datagen-9_2-zf |        59.48        |        3.50         |  N/A  |        **1.85**           |
-|    WCC    | datagen-9_0-fb |        16.99        |        1.05         |       2.85      |        **0.52**           |
-|           | datagen-9_1-fb |        30.33        |        1.24         |       3.80      |        **0.60**           |
-|           | datagen-9_2-zf |        231.79       |        6.58         |       30.79     |        **1.77**           |
-|           | graph500-26    |        17.36       |        1.98         |       4.96      |        **0.90**           |
-|           | com-friendster |        68.79       |        4.77         |       9.39      |        **2.40**           |
-|    BFS    | datagen-9_0-fb |        4.31         |        0.38         |      0.73       |        **0.23**           |
-|           | datagen-9_1-fb |        5.23         |        0.39         |      0.84       |        **0.26**           |
-|           | datagen-9_2-zf |        41.36        |        2.59         |      14.59      |        **1.64**           |
-|           | graph500-26    |        5.42         |        0.73         |      2.19       |        **0.43**           |
-|           | com-friendster |        13.14        |        1.28         |      3.55       |        **1.12**           |
-|  PageRank | datagen-9_0-fb |        26.90        |  X    |      X   |    **1.61**    |
-|           | datagen-9_1-fb |        34.01        |  X    |      X   |    **1.99**    |
-|           | datagen-9_2-zf |        152.11       |  X    |      X   |    **4.00**    |
-|           | graph500-26    |        34.89        |  X    |      X   |    **2.95**    |
-|           | com-friendster |        66.61        |  X    |      X   |    **5.91**    |
-|    CDLP   | datagen-9_0-fb |        1535.09      |  N/A    |     16.67   |    **8.49**    |
-|           | datagen-9_1-fb |        2725.54      |  N/A    |     21.60   |    **10.78**   |
-|           | datagen-9_2-zf |        > 3600       |  N/A    |     46.05   |    **17.17**   |
-|           | graph500-26    |        401.21       |  N/A    |     13.44   |    **8.50**    |
-|           | com-friendster |        > 3600       |  N/A    |     37.81   |    **20.17**   |
-|    LCC    | datagen-9_0-fb |        453.07       |      N/A            |      N/A      |         **16.53**       |
-|           | datagen-9_1-fb |        613.64       |      N/A            |      N/A      |         **20.83**       |
-|           | datagen-9_2-zf |        299.42       |      N/A            |      N/A      |         **19.81**       |
-|           | graph500-26    |        1838.60      |      N/A            |      N/A      |         **232.50**      |
-|           | com-friendster |        847.97       |      N/A            |      N/A      |         **68.52**       |
+| Algorithm | Dataset        | PowerGraph | GeminiGraph | Plato | libgrape-lite |
+|-----------|----------------|------------|-------------|-------|---------------|
+| SSSP      | datagen-9_0-fb | 5.08       | 0.62        | N/A   | **0.42**      |
+|           | datagen-9_1-fb | 5.30       | 0.78        | N/A   | **0.56**      |
+|           | datagen-9_2-zf | 41.19      | 3.75        | N/A   | **1.48**      |
+| WCC       | datagen-9_0-fb | 14.14      | 0.88        | 2.60  | **0.41**      |
+|           | datagen-9_1-fb | 18.61      | 1.17        | 3.07  | **0.50**      |
+|           | datagen-9_2-zf | 176.87     | 6.26        | 25.49 | **1.32**      |
+|           | graph500-26    | 13.71      | 1.60        | 4.79  | **0.71**      |
+|           | com-friendster | 44.20      | 3.97        | 7.80  | **1.97**      |
+| BFS       | datagen-9_0-fb | 3.90       | 0.24        | 0.59  | **0.07**      |
+|           | datagen-9_1-fb | 4.30       | 0.28        | 0.71  | **0.13**      |
+|           | datagen-9_2-zf | 39.11      | 1.97        | 10.37 | **1.16**      |
+|           | graph500-26    | 4.86       | 0.53        | 1.56  | **0.20**      |
+|           | com-friendster | 12.80      | 1.09        | 2.67  | **0.74**      |
+| PageRank  | datagen-9_0-fb | 22.57      | X           | X     | **1.40**      |
+|           | datagen-9_1-fb | 28.38      | X           | X     | **1.73**      |
+|           | datagen-9_2-zf | 126.98     | X           | X     | **3.83**      |
+|           | graph500-26    | 28.66      | X           | X     | **2.42**      |
+|           | com-friendster | 57.10      | X           | X     | **6.04**      |
+| CDLP      | datagen-9_0-fb | 1695.73    | N/A         | 16.30 | **8.18**      |
+|           | datagen-9_1-fb | 2742.47    | N/A         | 21.35 | **10.40**     |
+|           | datagen-9_2-zf | > 3600     | N/A         | 34.85 | **19.48**     |
+|           | graph500-26    | 425.55     | N/A         | 12.86 | **7.59**      |
+|           | com-friendster | > 3600     | N/A         | 36.87 | **19.10**     |
+| LCC       | datagen-9_0-fb | 521.26     | N/A         | N/A   | **14.51**     |
+|           | datagen-9_1-fb | 600.32     | N/A         | N/A   | **18.35**     |
+|           | datagen-9_2-zf | 296.18     | N/A         | N/A   | **8.98**      |
+|           | graph500-26    | 1859.86    | N/A         | N/A   | **201.20**    |
+|           | com-friendster | 842.68     | N/A         | N/A   | **61.44**     |
 
 
 We used “default” code provided by the competitor systems when it is available. 
@@ -58,13 +58,13 @@ The inconsistences of PageRank come from different settings on convergence condi
 To give a comprehensive comparison, we made our best efforts to revise our application([pagerank_local.h](examples/analytical_apps/pagerank/pagerank_local.h)), making them output the same results as competitor systems.
 The performance results are shown as below. 
 
-| Algorithm |     Dataset    |     GeminiGraph     |        Plato        | libgrape-lite   |
-|-----------|----------------|---------------------|---------------------|---------------------|
-|  PageRank | datagen-9_0-fb |        2.60         |        4.81         |      **1.69**       |
-|           | datagen-9_1-fb |        3.24         |        5.17         |      **1.88**       |
-|           | datagen-9_2-zf |        7.18         |        41.43        |      **2.99**       |
-|           | graph500-26    |        6.61         |        14.67        |      **2.88**       |
-|           | com-friendster |        9.90         |        18.65        |      **5.95**       |
+| Algorithm | Dataset        | GeminiGraph | Plato | libgrape-lite |
+|-----------|----------------|-------------|-------|---------------|
+| PageRank  | datagen-9_0-fb | 2.21        | 4.65  | **1.39**      |
+|           | datagen-9_1-fb | 2.72        | 5.38  | **1.73**      |
+|           | datagen-9_2-zf | 7.84        | 36.11 | **3.63**      |
+|           | graph500-26    | 4.75        | 12.25 | **2.34**      |
+|           | com-friendster | 8.19        | 15.82 | **5.84**      |
 
 
 ## Reproducing the results

--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ The latest version of online documentation can be found at [https://alibaba.gith
 
 - [flat_hash_map](https://github.com/skarupke/flat_hash_map), an efficient hashmap implementation;
 - [granula](https://github.com/atlarge-research/granula), a tool for gathering performance information for LDBC Benchmark;
-- [xoroshiro](http://prng.di.unimi.it/), a pseudo-random number generator.
+- [xoroshiro](http://prng.di.unimi.it/), a pseudo-random number generator;
+- [threadpool](https://github.com/progschj/threadpool), a concise C++11 Thread Pool implementation.
 
 
 ## Publications

--- a/examples/analytical_apps/bfs/bfs.h
+++ b/examples/analytical_apps/bfs/bfs.h
@@ -56,8 +56,8 @@ class BFS : public ParallelAppBase<FRAG_T, BFSContext<FRAG_T>>,
     auto outer_vertices = frag.OuterVertices();
 
     // init double buffer which contains updated vertices using bitmap
-    ctx.curr_inner_updated.Init(inner_vertices, thread_num());
-    ctx.next_inner_updated.Init(inner_vertices, thread_num());
+    ctx.curr_inner_updated.Init(inner_vertices, &GetThreadPool());
+    ctx.next_inner_updated.Init(inner_vertices, &GetThreadPool());
 
 #ifdef PROFILING
     ctx.exec_time -= GetCurrentTime();
@@ -102,7 +102,7 @@ class BFS : public ParallelAppBase<FRAG_T, BFSContext<FRAG_T>>,
 
     depth_type next_depth = ctx.current_depth + 1;
     int thrd_num = thread_num();
-    ctx.next_inner_updated.ParallelClear(thrd_num);
+    ctx.next_inner_updated.ParallelClear(&GetThreadPool());
 
 #ifdef PROFILING
     ctx.preprocess_time -= GetCurrentTime();
@@ -127,7 +127,7 @@ class BFS : public ParallelAppBase<FRAG_T, BFSContext<FRAG_T>>,
     if (ctx.avg_degree > 10) {
       auto ivnum = frag.GetInnerVerticesNum();
       rate = static_cast<double>(
-                 ctx.curr_inner_updated.ParallelCount(thread_num())) /
+                 ctx.curr_inner_updated.ParallelCount(&GetThreadPool())) /
              static_cast<double>(ivnum);
       if (rate > 0.1) {
         auto inner_vertices = frag.InnerVertices();

--- a/examples/analytical_apps/bfs/bfs.h
+++ b/examples/analytical_apps/bfs/bfs.h
@@ -56,8 +56,8 @@ class BFS : public ParallelAppBase<FRAG_T, BFSContext<FRAG_T>>,
     auto outer_vertices = frag.OuterVertices();
 
     // init double buffer which contains updated vertices using bitmap
-    ctx.curr_inner_updated.Init(inner_vertices, &GetThreadPool());
-    ctx.next_inner_updated.Init(inner_vertices, &GetThreadPool());
+    ctx.curr_inner_updated.Init(inner_vertices, GetThreadPool());
+    ctx.next_inner_updated.Init(inner_vertices, GetThreadPool());
 
 #ifdef PROFILING
     ctx.exec_time -= GetCurrentTime();
@@ -102,7 +102,7 @@ class BFS : public ParallelAppBase<FRAG_T, BFSContext<FRAG_T>>,
 
     depth_type next_depth = ctx.current_depth + 1;
     int thrd_num = thread_num();
-    ctx.next_inner_updated.ParallelClear(&GetThreadPool());
+    ctx.next_inner_updated.ParallelClear(GetThreadPool());
 
 #ifdef PROFILING
     ctx.preprocess_time -= GetCurrentTime();
@@ -127,7 +127,7 @@ class BFS : public ParallelAppBase<FRAG_T, BFSContext<FRAG_T>>,
     if (ctx.avg_degree > 10) {
       auto ivnum = frag.GetInnerVerticesNum();
       rate = static_cast<double>(
-                 ctx.curr_inner_updated.ParallelCount(&GetThreadPool())) /
+                 ctx.curr_inner_updated.ParallelCount(GetThreadPool())) /
              static_cast<double>(ivnum);
       if (rate > 0.1) {
         auto inner_vertices = frag.InnerVertices();

--- a/examples/analytical_apps/sssp/sssp.h
+++ b/examples/analytical_apps/sssp/sssp.h
@@ -60,7 +60,7 @@ class SSSP : public ParallelAppBase<FRAG_T, SSSPContext<FRAG_T>>,
     ctx.exec_time -= GetCurrentTime();
 #endif
 
-    ctx.next_modified.ParallelClear(&GetThreadPool());
+    ctx.next_modified.ParallelClear(GetThreadPool());
 
     // Get the channel. Messages assigned to this channel will be sent by the
     // message manager in parallel with the evaluation process.
@@ -113,7 +113,7 @@ class SSSP : public ParallelAppBase<FRAG_T, SSSPContext<FRAG_T>>,
     ctx.preprocess_time -= GetCurrentTime();
 #endif
 
-    ctx.next_modified.ParallelClear(&GetThreadPool());
+    ctx.next_modified.ParallelClear(GetThreadPool());
 
     // parallel process and reduce the received messages
     messages.ParallelProcess<fragment_t, double>(

--- a/examples/analytical_apps/sssp/sssp.h
+++ b/examples/analytical_apps/sssp/sssp.h
@@ -60,7 +60,7 @@ class SSSP : public ParallelAppBase<FRAG_T, SSSPContext<FRAG_T>>,
     ctx.exec_time -= GetCurrentTime();
 #endif
 
-    ctx.next_modified.ParallelClear(thread_num());
+    ctx.next_modified.ParallelClear(&GetThreadPool());
 
     // Get the channel. Messages assigned to this channel will be sent by the
     // message manager in parallel with the evaluation process.
@@ -113,7 +113,7 @@ class SSSP : public ParallelAppBase<FRAG_T, SSSPContext<FRAG_T>>,
     ctx.preprocess_time -= GetCurrentTime();
 #endif
 
-    ctx.next_modified.ParallelClear(thread_num());
+    ctx.next_modified.ParallelClear(&GetThreadPool());
 
     // parallel process and reduce the received messages
     messages.ParallelProcess<fragment_t, double>(

--- a/examples/analytical_apps/wcc/wcc.h
+++ b/examples/analytical_apps/wcc/wcc.h
@@ -150,7 +150,7 @@ class WCC : public ParallelAppBase<FRAG_T, WCCContext<FRAG_T>>,
                message_manager_t& messages) {
     using vid_t = typename context_t::vid_t;
 
-    ctx.next_modified.ParallelClear(&GetThreadPool());
+    ctx.next_modified.ParallelClear(GetThreadPool());
 
 #ifdef PROFILING
     ctx.preprocess_time -= GetCurrentTime();
@@ -171,7 +171,7 @@ class WCC : public ParallelAppBase<FRAG_T, WCCContext<FRAG_T>>,
 
     vid_t ivnum = frag.GetInnerVerticesNum();
     double rate = static_cast<double>(ctx.curr_modified.ParallelPartialCount(
-                      &GetThreadPool(), 0, ivnum)) /
+                      GetThreadPool(), 0, ivnum)) /
                   static_cast<double>(ivnum);
     // If active vertices are few, pushing will be used.
     if (rate > 0.1) {

--- a/examples/analytical_apps/wcc/wcc.h
+++ b/examples/analytical_apps/wcc/wcc.h
@@ -150,7 +150,7 @@ class WCC : public ParallelAppBase<FRAG_T, WCCContext<FRAG_T>>,
                message_manager_t& messages) {
     using vid_t = typename context_t::vid_t;
 
-    ctx.next_modified.ParallelClear(thread_num());
+    ctx.next_modified.ParallelClear(&GetThreadPool());
 
 #ifdef PROFILING
     ctx.preprocess_time -= GetCurrentTime();
@@ -171,7 +171,7 @@ class WCC : public ParallelAppBase<FRAG_T, WCCContext<FRAG_T>>,
 
     vid_t ivnum = frag.GetInnerVerticesNum();
     double rate = static_cast<double>(ctx.curr_modified.ParallelPartialCount(
-                      thread_num(), 0, ivnum)) /
+                      &GetThreadPool(), 0, ivnum)) /
                   static_cast<double>(ivnum);
     // If active vertices are few, pushing will be used.
     if (rate > 0.1) {

--- a/grape/parallel/parallel_engine_spec.h
+++ b/grape/parallel/parallel_engine_spec.h
@@ -1,0 +1,57 @@
+/** Copyright 2021 Alibaba Group Holding Limited.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef GRAPE_PARALLEL_PARALLEL_ENGINE_SPEC_H_
+#define GRAPE_PARALLEL_PARALLEL_ENGINE_SPEC_H_
+
+namespace grape {
+
+struct ParallelEngineSpec {
+  uint32_t thread_num;
+  bool affinity;
+  std::vector<uint32_t> cpu_list;
+};
+
+inline ParallelEngineSpec DefaultParallelEngineSpec() {
+  ParallelEngineSpec spec;
+  spec.thread_num = std::thread::hardware_concurrency();
+  spec.affinity = false;
+  spec.cpu_list.clear();
+  return spec;
+}
+
+inline ParallelEngineSpec MultiProcessSpec(const CommSpec& comm_spec,
+                                           bool affinity = false) {
+  ParallelEngineSpec spec;
+  uint32_t total_thread_num = std::thread::hardware_concurrency();
+  uint32_t each_process_thread_num =
+      (total_thread_num + comm_spec.local_num() - 1) / comm_spec.local_num();
+  spec.thread_num = each_process_thread_num;
+  spec.affinity = affinity;
+  spec.cpu_list.clear();
+  if (affinity) {
+    uint32_t offset = each_process_thread_num * comm_spec.local_id();
+    for (uint32_t i = 0, j = 0; i < each_process_thread_num; ++i, ++j) {
+      if (offset + j == total_thread_num)
+        j = 0;
+      spec.cpu_list.push_back(offset + j);
+    }
+  }
+  return spec;
+}
+
+}  // namespace grape
+
+#endif  // GRAPE_PARALLEL_PARALLEL_ENGINE_SPEC_H_

--- a/grape/utils/bitset.h
+++ b/grape/utils/bitset.h
@@ -21,6 +21,8 @@ limitations under the License.
 #include <algorithm>
 #include <utility>
 
+#include "thread_pool.h"
+
 #define WORD_SIZE(n) (((n) + 63ul) >> 6)
 
 #define WORD_INDEX(i) ((i) >> 6)
@@ -64,11 +66,21 @@ class Bitset {
     }
   }
 
-  void parallel_clear(int thread_num) {
-#pragma omp parallel for num_threads(thread_num)
-    for (size_t i = 0; i < size_in_words_; ++i) {
-      data_[i] = 0;
+  void parallel_clear(ThreadPool* thread_pool) {
+    uint32_t thread_num = thread_pool->GetThreadNum();
+    size_t chunk_size =
+        std::max(1024ul, (size_in_words_ + thread_num - 1) / thread_num);
+    size_t thread_begin = 0, thread_end = std::min(chunk_size, size_in_words_);
+    std::vector<std::future<void>> results(thread_num);
+    for (uint32_t tid = 0; tid < thread_num; ++tid) {
+      results[tid] = thread_pool->enqueue([thread_begin, thread_end, this]() {
+        for (size_t i = thread_begin; i < thread_end; ++i)
+          data_[i] = 0;
+      });
+      thread_begin = thread_end;
+      thread_end = std::min(thread_end + chunk_size, size_in_words_);
     }
+    thread_pool->WaitEnd(results);
   }
 
   bool empty() const {
@@ -146,12 +158,25 @@ class Bitset {
     return ret;
   }
 
-  size_t parallel_count(int thread_num) const {
+  size_t parallel_count(ThreadPool* thread_pool) const {
     size_t ret = 0;
-#pragma omp parallel for num_threads(thread_num) reduction(+ : ret)
-    for (size_t i = 0; i < size_in_words_; ++i) {
-      ret += __builtin_popcountll(data_[i]);
+    uint32_t thread_num = thread_pool->GetThreadNum();
+    size_t chunk_size =
+        std::max(1024ul, (size_in_words_ + thread_num - 1) / thread_num);
+    size_t thread_start = 0, thread_end = std::min(chunk_size, size_in_words_);
+    std::vector<std::future<void>> results(thread_num);
+    for (uint32_t tid = 0; tid < thread_num; ++tid) {
+      results[tid] =
+          thread_pool->enqueue([thread_start, thread_end, this, tid, &ret]() {
+            size_t ret_t = 0;
+            for (size_t i = thread_start; i < thread_end; ++i)
+              ret_t += __builtin_popcountll(data_[i]);
+            __sync_fetch_and_add(&ret, ret_t);
+          });
+      thread_start = thread_end;
+      thread_end = std::min(thread_end + chunk_size, size_in_words_);
     }
+    thread_pool->WaitEnd(results);
     return ret;
   }
 
@@ -177,17 +202,31 @@ class Bitset {
     return ret;
   }
 
-  size_t parallel_partial_count(int thread_num, size_t begin,
+  size_t parallel_partial_count(ThreadPool* thread_pool, size_t begin,
                                 size_t end) const {
     size_t ret = 0;
     size_t cont_beg = ROUND_UP(begin);
     size_t cont_end = ROUND_DOWN(end);
     size_t word_beg = WORD_INDEX(cont_beg);
     size_t word_end = WORD_INDEX(cont_end);
-#pragma omp parallel for num_threads(thread_num) reduction(+ : ret)
-    for (size_t i = word_beg; i < word_end; ++i) {
-      ret += __builtin_popcountll(data_[i]);
+    uint32_t thread_num = thread_pool->GetThreadNum();
+    size_t chunk_size =
+        std::max(1024ul, (word_end - word_beg + thread_num - 1) / thread_num);
+    size_t thread_begin = word_beg,
+           thread_end = std::min(word_beg + chunk_size, word_end);
+    std::vector<std::future<void>> results(thread_num);
+    for (uint32_t tid = 0; tid < thread_num; ++tid) {
+      results[tid] =
+          thread_pool->enqueue([thread_begin, thread_end, this, tid, &ret]() {
+            size_t ret_t = 0;
+            for (size_t i = thread_begin; i < thread_end; ++i)
+              ret_t += __builtin_popcountll(data_[i]);
+            __sync_fetch_and_add(&ret, ret_t);
+          });
+      thread_begin = thread_end;
+      thread_end = std::min(thread_end + chunk_size, word_end);
     }
+    thread_pool->WaitEnd(results);
     if (cont_beg != begin) {
       uint64_t first_word = data_[WORD_INDEX(begin)];
       first_word = (first_word >> (64 - (cont_beg - begin)));

--- a/grape/utils/bitset.h
+++ b/grape/utils/bitset.h
@@ -167,7 +167,7 @@ class Bitset {
     std::vector<std::future<void>> results(thread_num);
     for (uint32_t tid = 0; tid < thread_num; ++tid) {
       results[tid] =
-          thread_pool->enqueue([thread_start, thread_end, this, tid, &ret]() {
+          thread_pool->enqueue([thread_start, thread_end, this, &ret]() {
             size_t ret_t = 0;
             for (size_t i = thread_start; i < thread_end; ++i)
               ret_t += __builtin_popcountll(data_[i]);
@@ -217,7 +217,7 @@ class Bitset {
     std::vector<std::future<void>> results(thread_num);
     for (uint32_t tid = 0; tid < thread_num; ++tid) {
       results[tid] =
-          thread_pool->enqueue([thread_begin, thread_end, this, tid, &ret]() {
+          thread_pool->enqueue([thread_begin, thread_end, this, &ret]() {
             size_t ret_t = 0;
             for (size_t i = thread_begin; i < thread_end; ++i)
               ret_t += __builtin_popcountll(data_[i]);

--- a/grape/utils/thread_pool.h
+++ b/grape/utils/thread_pool.h
@@ -22,7 +22,7 @@
  3. This notice may not be removed or altered from any source
  distribution.
  
- Modified by 2020 Alibaba Group to use in this project
+ Modified by Binrui Li at Alibaba Group, 2021.
 */
 
 #ifndef GRAPE_UTILS_THREAD_POOL_H_

--- a/grape/utils/thread_pool.h
+++ b/grape/utils/thread_pool.h
@@ -1,0 +1,131 @@
+/** Credits to Jakob Progsch (@progschj)
+ https://github.com/progschj/ThreadPool
+ 
+ Copyright (c) 2012 Jakob Progsch, Václav Zeman
+ 
+ This software is provided 'as-is', without any express or implied
+ warranty. In no event will the authors be held liable for any damages
+ arising from the use of this software.
+ 
+ Permission is granted to anyone to use this software for any purpose,
+ including commercial applications, and to alter it and redistribute it
+ freely, subject to the following restrictions:
+ 
+ 1. The origin of this software must not be misrepresented; you must not
+ claim that you wrote the original software. If you use this software
+ in a product, an acknowledgment in the product documentation would be
+ appreciated but is not required.
+ 
+ 2. Altered source versions must be plainly marked as such, and must not be
+ misrepresented as being the original software.
+ 
+ 3. This notice may not be removed or altered from any source
+ distribution.
+ 
+ Modified by 2020 Alibaba Group to use in this project
+*/
+
+#ifndef GRAPE_UTILS_THREAD_POOL_H_
+#define GRAPE_UTILS_THREAD_POOL_H_
+
+#include <condition_variable>
+#include <functional>
+#include <future>
+#include <memory>
+#include <mutex>
+#include <queue>
+#include <stdexcept>
+#include <thread>
+#include <vector>
+
+class ThreadPool {
+ public:
+  ThreadPool(ThreadPool const&) = delete;
+  ThreadPool& operator=(ThreadPool const&) = delete;
+  ThreadPool() {}
+  inline void InitThreadPool(size_t);
+
+  template <class F, class... Args>
+  auto enqueue(F&& f, Args&&... args)
+      -> std::future<typename std::result_of<F(Args...)>::type>;
+  inline int GetThreadNum() { return thread_num_; }
+  void WaitEnd(std::vector<std::future<void>>& results);
+  ~ThreadPool();
+
+ private:
+  // need to keep track of threads so we can join them
+  std::vector<std::thread> workers;
+  // the task queue
+  std::queue<std::function<void()>> tasks;
+
+  // synchronization
+  std::mutex queue_mutex;
+  std::condition_variable condition;
+  bool stop{false};
+  size_t thread_num_{1};
+};
+
+// the constructor just launches some amount of workers
+inline void ThreadPool::InitThreadPool(size_t threads) {
+  thread_num_ = threads;
+  for (size_t i = 0; i < threads; ++i)
+    workers.emplace_back([this] {
+      for (;;) {
+        std::function<void()> task;
+
+        {
+          std::unique_lock<std::mutex> lock(this->queue_mutex);
+          this->condition.wait(
+              lock, [this] { return this->stop || !this->tasks.empty(); });
+          if (this->stop && this->tasks.empty())
+            return;
+          task = std::move(this->tasks.front());
+          this->tasks.pop();
+        }
+
+        task();
+      }
+    });
+}
+
+// use to wait for all tasks end
+inline void ThreadPool::WaitEnd(std::vector<std::future<void>>& results) {
+  for (size_t tid = 0; tid < thread_num_; ++tid)
+    results[tid].get();
+}
+
+// add new task to the pool
+template <class F, class... Args>
+auto ThreadPool::enqueue(F&& f, Args&&... args)
+    -> std::future<typename std::result_of<F(Args...)>::type> {
+  using return_type = typename std::result_of<F(Args...)>::type;
+
+  auto task = std::make_shared<std::packaged_task<return_type()>>(
+      std::bind(std::forward<F>(f), std::forward<Args>(args)...));
+
+  std::future<return_type> res = task->get_future();
+  {
+    std::unique_lock<std::mutex> lock(queue_mutex);
+
+    // don't allow enqueueing after stopping the pool
+    if (stop)
+      throw std::runtime_error("enqueue on stopped ThreadPool");
+
+    tasks.emplace([task]() { (*task)(); });
+  }
+  condition.notify_one();
+  return res;
+}
+
+// the destructor joins all threads
+inline ThreadPool::~ThreadPool() {
+  {
+    std::unique_lock<std::mutex> lock(queue_mutex);
+    stop = true;
+  }
+  condition.notify_all();
+  for (std::thread& worker : workers)
+    worker.join();
+}
+
+#endif  // GRAPE_UTILS_THREAD_POOL_H_

--- a/grape/utils/vertex_set.h
+++ b/grape/utils/vertex_set.h
@@ -40,30 +40,36 @@ class DenseVertexSet {
 
   ~DenseVertexSet() = default;
 
-  void Init(const VertexRange<VID_T>& range,
-            ThreadPool* thread_pool = nullptr) {
+  void Init(const VertexRange<VID_T>& range, ThreadPool& thread_pool) {
     beg_ = range.begin().GetValue();
     end_ = range.end().GetValue();
     bs_.init(end_ - beg_);
-    if (thread_pool == nullptr) {
-      bs_.clear();
-    } else {
-      bs_.parallel_clear(thread_pool);
-    }
+    bs_.parallel_clear(thread_pool);
   }
 
-  void Init(const VertexVector<VID_T>& vertices,
-            ThreadPool* thread_pool = nullptr) {
+  void Init(const VertexVector<VID_T>& vertices, ThreadPool& thread_pool) {
     if (vertices.size() == 0)
       return;
     beg_ = vertices[0].GetValue();
     end_ = vertices[vertices.size() - 1].GetValue();
     bs_.init(end_ - beg_ + 1);
-    if (thread_pool == nullptr) {
-      bs_.clear();
-    } else {
-      bs_.parallel_clear(thread_pool);
-    }
+    bs_.parallel_clear(thread_pool);
+  }
+
+  void Init(const VertexRange<VID_T>& range) {
+    beg_ = range.begin().GetValue();
+    end_ = range.end().GetValue();
+    bs_.init(end_ - beg_);
+    bs_.clear();
+  }
+
+  void Init(const VertexVector<VID_T>& vertices) {
+    if (vertices.size() == 0)
+      return;
+    beg_ = vertices[0].GetValue();
+    end_ = vertices[vertices.size() - 1].GetValue();
+    bs_.init(end_ - beg_ + 1);
+    bs_.clear();
   }
 
   void Insert(Vertex<VID_T> u) { bs_.set_bit(u.GetValue() - beg_); }
@@ -84,7 +90,7 @@ class DenseVertexSet {
 
   size_t Count() const { return bs_.count(); }
 
-  size_t ParallelCount(ThreadPool* thread_pool) const {
+  size_t ParallelCount(ThreadPool& thread_pool) const {
     return bs_.parallel_count(thread_pool);
   }
 
@@ -92,14 +98,14 @@ class DenseVertexSet {
     return bs_.partial_count(beg - beg_, end - beg_);
   }
 
-  size_t ParallelPartialCount(ThreadPool* thread_pool, VID_T beg,
+  size_t ParallelPartialCount(ThreadPool& thread_pool, VID_T beg,
                               VID_T end) const {
     return bs_.parallel_partial_count(thread_pool, beg - beg_, end - beg_);
   }
 
   void Clear() { bs_.clear(); }
 
-  void ParallelClear(ThreadPool* thread_pool) {
+  void ParallelClear(ThreadPool& thread_pool) {
     bs_.parallel_clear(thread_pool);
   }
 

--- a/grape/utils/vertex_set.h
+++ b/grape/utils/vertex_set.h
@@ -19,6 +19,7 @@ limitations under the License.
 #include <utility>
 
 #include "grape/utils/bitset.h"
+#include "grape/utils/thread_pool.h"
 #include "grape/utils/vertex_array.h"
 
 namespace grape {
@@ -39,27 +40,29 @@ class DenseVertexSet {
 
   ~DenseVertexSet() = default;
 
-  void Init(const VertexRange<VID_T>& range, int thread_num = 1) {
+  void Init(const VertexRange<VID_T>& range,
+            ThreadPool* thread_pool = nullptr) {
     beg_ = range.begin().GetValue();
     end_ = range.end().GetValue();
     bs_.init(end_ - beg_);
-    if (thread_num == 1) {
+    if (thread_pool == nullptr) {
       bs_.clear();
     } else {
-      bs_.parallel_clear(thread_num);
+      bs_.parallel_clear(thread_pool);
     }
   }
 
-  void Init(const VertexVector<VID_T>& vertices, int thread_num = 1) {
+  void Init(const VertexVector<VID_T>& vertices,
+            ThreadPool* thread_pool = nullptr) {
     if (vertices.size() == 0)
       return;
     beg_ = vertices[0].GetValue();
     end_ = vertices[vertices.size() - 1].GetValue();
     bs_.init(end_ - beg_ + 1);
-    if (thread_num == 1) {
+    if (thread_pool == nullptr) {
       bs_.clear();
     } else {
-      bs_.parallel_clear(thread_num);
+      bs_.parallel_clear(thread_pool);
     }
   }
 
@@ -81,21 +84,24 @@ class DenseVertexSet {
 
   size_t Count() const { return bs_.count(); }
 
-  size_t ParallelCount(int thread_num) const {
-    return bs_.parallel_count(thread_num);
+  size_t ParallelCount(ThreadPool* thread_pool) const {
+    return bs_.parallel_count(thread_pool);
   }
 
   size_t PartialCount(VID_T beg, VID_T end) const {
     return bs_.partial_count(beg - beg_, end - beg_);
   }
 
-  size_t ParallelPartialCount(int thread_num, VID_T beg, VID_T end) const {
-    return bs_.parallel_partial_count(thread_num, beg - beg_, end - beg_);
+  size_t ParallelPartialCount(ThreadPool* thread_pool, VID_T beg,
+                              VID_T end) const {
+    return bs_.parallel_partial_count(thread_pool, beg - beg_, end - beg_);
   }
 
   void Clear() { bs_.clear(); }
 
-  void ParallelClear(int thread_num) { bs_.parallel_clear(thread_num); }
+  void ParallelClear(ThreadPool* thread_pool) {
+    bs_.parallel_clear(thread_pool);
+  }
 
   void Swap(DenseVertexSet<VID_T>& rhs) {
     std::swap(beg_, rhs.beg_);


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/libgrape-lite/blob/master/CONTRIBUTING.rst before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

1. add a ThreadPool class member to ParallelEngine for support of thread reuse in ForEach functions.
2. delivery the ThreadPool to BitSet for support of parallel functions which are previously implemented with openmp.

## Performance Improvement Results

<!-- Are there any issues opened that will be resolved by merging this change? -->

The experiments were conducted on 4 instances of [r6e.8xlarge] on [AlibabaCloud ECS], each with 32 threads. All the results are averages of 10 runs.

|Algorithm	 |Dataset    	    |Baseline	|Thread Pool	|Improvements|
|------------|------------------|-----------|---------------|------------|
|    SSSP   	 |datagen-9_0-fb 	|0.622	    |0.588	    |6%|
|           	 |datagen-9_1-fb 	|0.765	    |0.765	    |0%|
|           	 |datagen-9_2-zf 	|1.707	    |1.587	    |8%|
|    WCC    	 |datagen-9_0-fb 	|0.764	    |0.725	    |5%|
|           	 |datagen-9_1-fb 	|0.903	    |0.883	    |2%|
|           	 |datagen-9_2-zf 	|1.893	    |1.454	    |30%|
|           	 |graph500-26    	|1.360	    |1.324	    |3%|
|           	 |com-friendster 	|2.763	    |2.685	    |3%|
|    BFS    	 |datagen-9_0-fb 	|0.143	    |0.095	    |50%|
|           	 |datagen-9_1-fb 	|0.187	    |0.146	    |28%|
|           	 |datagen-9_2-zf 	|1.317	    |1.240	    |6%|
|           	 |graph500-26    	|0.264	    |0.211	    |25%|
|           	 |com-friendster 	|0.974	    |0.884	    |10%|
|  PageRank 	 |datagen-9_0-fb 	|2.674	    |2.655	    |1%|
|           	 |datagen-9_1-fb 	|3.493	    |3.456	    |1%|
|           	 |datagen-9_2-zf 	|3.953	    |4.130	    |-4%|
|           	 |graph500-26    	|4.645	    |4.593	    |1%|
|           	 |com-friendster 	|9.659	    |9.626	    |0%|
|    CDLP   	 |datagen-9_0-fb 	|9.099	    |9.086	    |0%|
|           	 |datagen-9_1-fb 	|11.590	    |11.567	    |0%|
|           	 |datagen-9_2-zf 	|17.511	    |18.068	    |-3%|
|           	 |graph500-26    	|9.997	    |9.935	    |1%|
|           	 |com-friendster 	|22.564	    |22.563	    |0%|
|    LCC    	 |datagen-9_0-fb 	|13.268	    |13.774	    |-4%|
|           	 |datagen-9_1-fb 	|16.779	    |17.450	    |-4%|
|           	 |datagen-9_2-zf 	|6.999	    |7.081	    |-1%|
|           	 |graph500-26    	|213.669	    |214.269	    |0%|
|           	 |com-friendster 	|60.887	    |62.782	    |-3%|