### PR TITLE
Fix ldbc_driver bug when run with multiple nodes

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -28,6 +28,8 @@ jobs:
           cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
           chmod og-wx ~/.ssh/authorized_keys
           chmod 750 $HOME
+          echo "StrictHostKeyChecking no" >> ~/.ssh/config
+          sudo systemctl restart sshd
           sudo apt install -y libmpich-dev libgoogle-glog-dev libgflags-dev librdkafka-dev
       - name: Install Dependencies for macOS
         if: runner.os == 'macOS'
@@ -56,9 +58,6 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           ./misc/sampler_test.sh
-      - name: Setup tmate session
-        if: runner.os == 'Linux'
-        uses: mxschmitt/action-tmate@v2
       - name: Run LDBC
         if: runner.os == 'Linux'
         run: |

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -52,6 +52,9 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           ./misc/sampler_test.sh
+      - name: Setup tmate session
+        if: runner.os == 'Linux'
+        uses: mxschmitt/action-tmate@v2
       - name: Run LDBC
         if: runner.os == 'Linux'
         run: |

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -56,6 +56,9 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           ./misc/sampler_test.sh
+      - name: Setup tmate session
+        if: runner.os == 'Linux'
+        uses: mxschmitt/action-tmate@v2
       - name: Run LDBC
         if: runner.os == 'Linux'
         run: |

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -29,7 +29,6 @@ jobs:
           chmod og-wx ~/.ssh/authorized_keys
           chmod 750 $HOME
           echo "StrictHostKeyChecking no" >> ~/.ssh/config
-          sudo systemctl restart sshd
           sudo apt install -y libmpich-dev libgoogle-glog-dev libgflags-dev librdkafka-dev
       - name: Install Dependencies for macOS
         if: runner.os == 'macOS'

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           # microsoft repo in 18.04 is broken
           # sudo apt update -y
-          cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
+          cat ~/.ssh/id_rsa.pub > ~/.ssh/authorized_keys
           chmod og-wx ~/.ssh/authorized_keys
           chmod 750 $HOME
           sudo apt install -y libmpich-dev libgoogle-glog-dev libgflags-dev librdkafka-dev

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -24,6 +24,7 @@ jobs:
         run: |
           # microsoft repo in 18.04 is broken
           # sudo apt update -y
+          ls ~/.ssh
           cat ~/.ssh/id_rsa.pub > ~/.ssh/authorized_keys
           chmod og-wx ~/.ssh/authorized_keys
           chmod 750 $HOME

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -24,8 +24,8 @@ jobs:
         run: |
           # microsoft repo in 18.04 is broken
           # sudo apt update -y
-          ls ~/.ssh
-          cat ~/.ssh/id_rsa.pub > ~/.ssh/authorized_keys
+          ssh-keygen -t rsa -f ~/.ssh/id_rsa -N ''
+          cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
           chmod og-wx ~/.ssh/authorized_keys
           chmod 750 $HOME
           sudo apt install -y libmpich-dev libgoogle-glog-dev libgflags-dev librdkafka-dev

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -26,6 +26,7 @@ jobs:
           # sudo apt update -y
           cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
           chmod og-wx ~/.ssh/authorized_keys
+          chmod 750 $HOME
           sudo apt install -y libmpich-dev libgoogle-glog-dev libgflags-dev librdkafka-dev
       - name: Install Dependencies for macOS
         if: runner.os == 'macOS'

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -24,6 +24,8 @@ jobs:
         run: |
           # microsoft repo in 18.04 is broken
           # sudo apt update -y
+          cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
+          chmod og-wx ~/.ssh/authorized_keys
           sudo apt install -y libmpich-dev libgoogle-glog-dev libgflags-dev librdkafka-dev
       - name: Install Dependencies for macOS
         if: runner.os == 'macOS'
@@ -52,9 +54,6 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           ./misc/sampler_test.sh
-      - name: Setup tmate session
-        if: runner.os == 'Linux'
-        uses: mxschmitt/action-tmate@v2
       - name: Run LDBC
         if: runner.os == 'Linux'
         run: |

--- a/ldbc_driver/bin/sh/compile-benchmark.sh
+++ b/ldbc_driver/bin/sh/compile-benchmark.sh
@@ -39,7 +39,7 @@ GRANULA_ENABLED=$(grep -E "^benchmark.run.granula.enabled[	 ]*[:=]" $config/gran
 
 # Build binaries
 mkdir -p bin/standard
-(cd bin/standard && cmake -DCMAKE_BUILD_TYPE=Release ${LIBGRAPE_HOME} && make analytical_apps)
+(cd bin/standard && cmake -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release ${LIBGRAPE_HOME} && make analytical_apps)
 
 if [ "$GRANULA_ENABLED" = "true" ] ; then
  mkdir -p bin/granula

--- a/ldbc_driver/bin/sh/run-mpi.sh
+++ b/ldbc_driver/bin/sh/run-mpi.sh
@@ -25,7 +25,11 @@ LOG_PATH=$2
 LIBGRAPE_HOME=$3
 FINAL_OUT=$4
 echo ${@:5}
+# the binary is sync to ${HOME}/bin/standard/run_app
+# switch $HOME before mpirun
+push ${HOME}
 mpirun --map-by ppr:1:node --bind-to none --host $1 ${@:5} &
+popd
 
 echo $! > $LOG_PATH/executable.pid
 wait $!

--- a/ldbc_driver/bin/sh/run-mpi.sh
+++ b/ldbc_driver/bin/sh/run-mpi.sh
@@ -27,7 +27,7 @@ FINAL_OUT=$4
 echo ${@:5}
 # the binary is sync to ${HOME}/bin/standard/run_app
 # switch $HOME before mpirun
-push ${HOME}
+pushd ${HOME}
 mpirun --map-by ppr:1:node --bind-to none --host $1 ${@:5} &
 popd
 

--- a/ldbc_driver/bin/sh/run-mpi.sh
+++ b/ldbc_driver/bin/sh/run-mpi.sh
@@ -26,7 +26,7 @@ LIBGRAPE_HOME=$3
 FINAL_OUT=$4
 echo ${@:5}
 # the binary is sync to ${HOME}/bin/standard/run_app
-# switch $HOME before mpirun
+# switch to $HOME before mpirun
 pushd ${HOME}
 mpirun --map-by ppr:1:node --bind-to none --host $1 ${@:5} &
 popd


### PR DESCRIPTION

## What do these changes do?
- build analytical_apps with  DBUILD_SHARED_LIBS=OFF ( that no need to sync libgrape-lite.so to other nodes)
- switch to $HOME before we run mpirun
