### PR TITLE
Fix compilation failure under high version gcc(>=10) with -Werror options

### DIFF
--- a/grape/fragment/immutable_edgecut_fragment.h
+++ b/grape/fragment/immutable_edgecut_fragment.h
@@ -723,14 +723,14 @@ class ImmutableEdgecutFragment
   }
 
   inline OID_T GetInnerVertexId(const vertex_t& v) const override {
-    OID_T internal_oid;
+    OID_T internal_oid{};
     vm_ptr_->GetOid(fid_, v.GetValue(), internal_oid);
     return internal_oid;
   }
 
   inline OID_T GetOuterVertexId(const vertex_t& v) const override {
     VID_T gid = ovgid_[v.GetValue() - ivnum_];
-    OID_T internal_oid;
+    OID_T internal_oid{};
     vm_ptr_->GetOid(gid, internal_oid);
     return internal_oid;
   }


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/libgrape-lite/blob/master/CONTRIBUTING.rst before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes
