### PR TITLE
[Fix bug] Resize ivdata_ and ovdata_ when mutation.vertices_to_add not empty

### DIFF
--- a/grape/fragment/mutable_edgecut_fragment.h
+++ b/grape/fragment/mutable_edgecut_fragment.h
@@ -303,6 +303,10 @@ class MutableEdgecutFragment
       oe_.add_vertices(new_ivnum - ivnum, new_ovnum - ovnum);
       oe_.add_edges(edges_to_add);
     }
+    if (!mutation.vertices_to_add.empty()) {
+      ivdata_.resize(this->ivnum_);
+      ovdata_.resize(ovnum_);
+    }
     for (auto& v : mutation.vertices_to_add) {
       vid_t lid;
       if (IsInnerVertexGid(v.vid)) {


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/libgrape-lite/blob/master/CONTRIBUTING.rst before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes
