### PR TITLE
Disable the cuda runner as we don't have a self-hosted runner currently.

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -8,6 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [self-hosted]
+    if: ${{ false }}
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION

## What do these changes do?

Disable the cuda CI to ensure our master branch keeps green.