### PR TITLE
Fix compile failure under gcc5.4 by adding default constructor to FragmentBase

### DIFF
--- a/grape/fragment/fragment_base.h
+++ b/grape/fragment/fragment_base.h
@@ -57,6 +57,8 @@ class FragmentBase {
   using fragment_const_adj_list_t =
       typename TRAITS_T::fragment_const_adj_list_t;
 
+  FragmentBase(): vm_ptr_(nullptr) {}
+
   explicit FragmentBase(std::shared_ptr<vertex_map_t> vm_ptr)
       : vm_ptr_(vm_ptr) {}
 


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/libgrape-lite/blob/master/CONTRIBUTING.rst before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes
