### PR TITLE
Add move constructor to `Vertex`,  `Edge` and `Nbr`

### DIFF
--- a/grape/graph/adj_list.h
+++ b/grape/graph/adj_list.h
@@ -43,6 +43,8 @@ struct Nbr {
       : neighbor(nbr_), data(data_) {}
   DEV_HOST Nbr(const Vertex<VID_T>& nbr_, const EDATA_T& data_)
       : neighbor(nbr_), data(data_) {}
+  DEV_HOST Nbr(const VID_T& nbr_, EDATA_T&& data_)
+      : neighbor(nbr_), data(std::move(data_)) {}
   DEV_HOST ~Nbr() {}
 
   DEV_HOST_INLINE Nbr& operator=(const Nbr& rhs) {

--- a/grape/graph/adj_list.h
+++ b/grape/graph/adj_list.h
@@ -39,7 +39,8 @@ struct Nbr {
   DEV_HOST explicit Nbr(const VID_T& nbr_) : neighbor(nbr_), data() {}
   DEV_HOST explicit Nbr(const Vertex<VID_T>& nbr_) : neighbor(nbr_), data() {}
   DEV_HOST Nbr(const Nbr& rhs) : neighbor(rhs.neighbor), data(rhs.data) {}
-  DEV_HOST Nbr(Nbr&& rhs) noexcept : neighbor(rhs.neighbor), data(std::move(rhs.data)) {}
+  DEV_HOST Nbr(Nbr&& rhs)
+      noexcept : neighbor(rhs.neighbor), data(std::move(rhs.data)) {}
   DEV_HOST Nbr(const VID_T& nbr_, const EDATA_T& data_)
       : neighbor(nbr_), data(data_) {}
   DEV_HOST Nbr(const Vertex<VID_T>& nbr_, const EDATA_T& data_)

--- a/grape/graph/adj_list.h
+++ b/grape/graph/adj_list.h
@@ -39,6 +39,7 @@ struct Nbr {
   DEV_HOST explicit Nbr(const VID_T& nbr_) : neighbor(nbr_), data() {}
   DEV_HOST explicit Nbr(const Vertex<VID_T>& nbr_) : neighbor(nbr_), data() {}
   DEV_HOST Nbr(const Nbr& rhs) : neighbor(rhs.neighbor), data(rhs.data) {}
+  DEV_HOST Nbr(Nbr&& rhs) noexcept : neighbor(rhs.neighbor), data(std::move(rhs.data)) {}
   DEV_HOST Nbr(const VID_T& nbr_, const EDATA_T& data_)
       : neighbor(nbr_), data(data_) {}
   DEV_HOST Nbr(const Vertex<VID_T>& nbr_, const EDATA_T& data_)

--- a/grape/graph/edge.h
+++ b/grape/graph/edge.h
@@ -44,6 +44,7 @@ struct Edge {
   DEV_HOST Edge(const Edge& e) : src(e.src), dst(e.dst), edata(e.edata) {}
   DEV_HOST Edge(const VID_T& src, const VID_T& dst, EDATA_T&& edata)
       : src(src), dst(dst), edata(std::move(edata)) {}
+  DEV_HOST Edge(Edge&& e) noexcept : src(e.src), dst(e.dst), edata(std::move(e.edata)) {}
 
   DEV_HOST Edge& operator=(const Edge& other) {
     if (this == &other) {

--- a/grape/graph/edge.h
+++ b/grape/graph/edge.h
@@ -42,6 +42,8 @@ struct Edge {
   DEV_HOST Edge(const VID_T& src, const VID_T& dst, const EDATA_T& edata)
       : src(src), dst(dst), edata(edata) {}
   DEV_HOST Edge(const Edge& e) : src(e.src), dst(e.dst), edata(e.edata) {}
+  DEV_HOST Edge(const VID_T& src, const VID_T& dst, EDATA_T&& edata)
+      : src(src), dst(dst), edata(std::move(edata)) {}
 
   DEV_HOST Edge& operator=(const Edge& other) {
     if (this == &other) {
@@ -50,6 +52,16 @@ struct Edge {
     src = other.src;
     dst = other.dst;
     edata = other.edata;
+    return *this;
+  }
+
+  DEV_HOST Edge& operator=(Edge&& other) {
+    if (this == &other) {
+      return *this;
+    }
+    src = other.src;
+    dst = other.dst;
+    edata = std::move(other.edata);
     return *this;
   }
 

--- a/grape/graph/edge.h
+++ b/grape/graph/edge.h
@@ -44,7 +44,8 @@ struct Edge {
   DEV_HOST Edge(const Edge& e) : src(e.src), dst(e.dst), edata(e.edata) {}
   DEV_HOST Edge(const VID_T& src, const VID_T& dst, EDATA_T&& edata)
       : src(src), dst(dst), edata(std::move(edata)) {}
-  DEV_HOST Edge(Edge&& e) noexcept : src(e.src), dst(e.dst), edata(std::move(e.edata)) {}
+  DEV_HOST Edge(Edge&& e)
+      noexcept : src(e.src), dst(e.dst), edata(std::move(e.edata)) {}
 
   DEV_HOST Edge& operator=(const Edge& other) {
     if (this == &other) {

--- a/grape/graph/vertex.h
+++ b/grape/graph/vertex.h
@@ -41,7 +41,11 @@ struct Vertex {
   DEV_HOST explicit Vertex(const VID_T& vid) : vid(vid), vdata() {}
   DEV_HOST Vertex(const VID_T& vid, const VDATA_T& vdata)
       : vid(vid), vdata(vdata) {}
+  DEV_HOST Vertex(const VID_T& vid, VDATA_T&& vdata)
+      : vid(vid), vdata(std::move(vdata)) {}
   DEV_HOST Vertex(const Vertex& vert) : vid(vert.vid), vdata(vert.vdata) {}
+  DEV_HOST Vertex(Vertex&& vert)
+      : vid(vert.vid), vdata(std::move(std::vert.vdata)) {}
 
   DEV_HOST ~Vertex() {}
 

--- a/grape/graph/vertex.h
+++ b/grape/graph/vertex.h
@@ -45,7 +45,7 @@ struct Vertex {
       : vid(vid), vdata(std::move(vdata)) {}
   DEV_HOST Vertex(const Vertex& vert) : vid(vert.vid), vdata(vert.vdata) {}
   DEV_HOST Vertex(Vertex&& vert)
-      : vid(vert.vid), vdata(std::move(std::vert.vdata)) {}
+      : vid(vert.vid), vdata(std::move(vert.vdata)) {}
 
   DEV_HOST ~Vertex() {}
 

--- a/grape/graph/vertex.h
+++ b/grape/graph/vertex.h
@@ -44,8 +44,8 @@ struct Vertex {
   DEV_HOST Vertex(const VID_T& vid, VDATA_T&& vdata)
       : vid(vid), vdata(std::move(vdata)) {}
   DEV_HOST Vertex(const Vertex& vert) : vid(vert.vid), vdata(vert.vdata) {}
-  DEV_HOST Vertex(Vertex&& vert) noexcept
-      : vid(vert.vid), vdata(std::move(vert.vdata)) {}
+  DEV_HOST Vertex(Vertex&& vert)
+      noexcept : vid(vert.vid), vdata(std::move(vert.vdata)) {}
 
   DEV_HOST ~Vertex() {}
 

--- a/grape/graph/vertex.h
+++ b/grape/graph/vertex.h
@@ -44,7 +44,7 @@ struct Vertex {
   DEV_HOST Vertex(const VID_T& vid, VDATA_T&& vdata)
       : vid(vid), vdata(std::move(vdata)) {}
   DEV_HOST Vertex(const Vertex& vert) : vid(vert.vid), vdata(vert.vdata) {}
-  DEV_HOST Vertex(Vertex&& vert)
+  DEV_HOST Vertex(Vertex&& vert) noexcept
       : vid(vert.vid), vdata(std::move(vert.vdata)) {}
 
   DEV_HOST ~Vertex() {}


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/libgrape-lite/blob/master/CONTRIBUTING.rst before opening an issue.
-->

## What do these changes do?
- Add move constructor to `Vertex`, `Edge` and `Nbr`;
- Mark these ctors with `noexcept` to avoid copy when vector of these structures grows. This is for complex data structure.

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes
