### PR TITLE
Support uint64 type in parallelMessage

### DIFF
--- a/examples/analytical_apps/pagerank/pagerank_local.h
+++ b/examples/analytical_apps/pagerank/pagerank_local.h
@@ -197,7 +197,7 @@ class PageRankLocal
       }
 
       if (!last_step) {
-        ForEach(inner_vertices, [&frag, &ctx](int tid, Vertex<uint32_t> u) {
+        ForEach(inner_vertices, [&frag, &ctx](int tid, vertex_t u) {
           int en = frag.GetLocalOutDegree(u);
           if (en > 0) {
             ctx.next_result[u] /= en;

--- a/grape/parallel/auto_parallel_message_manager.h
+++ b/grape/parallel/auto_parallel_message_manager.h
@@ -177,6 +177,9 @@ class AutoParallelMessageManager : public DefaultMessageManager {
         } else if (event->buffer->GetTypeId() == typeid(int64_t)) {
           syncOnOuterVertexSend<int64_t>(i_ec_frag, event->buffer,
                                          event->event_id);
+        } else if (event->buffer->GetTypeId() == typeid(uint64_t)) {
+          syncOnOuterVertexSend<uint64_t>(i_ec_frag, event->buffer,
+                                        event->event_id);
         } else {
           LOG(FATAL) << "Unexpected data type for auto parallelization: "
                      << event->buffer->GetTypeId().name();


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/libgrape-lite/blob/master/CONTRIBUTING.rst before opening an issue.
-->

## What do these changes do?

Test wcc_auto failed in graphscope  with `uint64_t` vid_t

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes https://github.com/alibaba/GraphScope/issues/1640
