### PR TITLE
Add interfaces following MutableCSR

### DIFF
--- a/grape/graph/de_mutable_csr.h
+++ b/grape/graph/de_mutable_csr.h
@@ -161,6 +161,10 @@ class DeMutableCSR<VID_T, Nbr<VID_T, EDATA_T>> {
 
   size_t edge_num() const { return head_.edge_num() + tail_.edge_num(); }
 
+  size_t head_edge_num() const { return head_.edge_num(); }
+
+  size_t tail_edge_num() const { return tail_.edge_num(); }
+
   int degree(VID_T i) const {
     return in_head(i) ? head_.degree(head_index(i))
                       : tail_.degree(tail_index(i));

--- a/grape/graph/de_mutable_csr.h
+++ b/grape/graph/de_mutable_csr.h
@@ -208,6 +208,25 @@ class DeMutableCSR<VID_T, Nbr<VID_T, EDATA_T>> {
                       : tail_.get_end(tail_index(i));
   }
 
+  nbr_t* find(VID_T i, VID_T nbr) {
+    return in_head(i) ? head_.find(head_index(i), nbr)
+                      : tail_.find(tail_index(i), nbr);
+  }
+
+  const nbr_t* find(VID_T i, VID_T nbr) const {
+    return in_head(i) ? head_.find(head_index(i), nbr)
+                      : tail_.find(tail_index(i), nbr);
+  }
+
+  nbr_t* binary_find(VID_T i, VID_T nbr) {
+    return in_head(i) ? head_.binary_find(head_index(i), nbr)
+                      : tail_.binary_find(tail_index(i), nbr);
+  }
+  const nbr_t* binary_find(VID_T i, VID_T nbr) const {
+    return in_head(i) ? head_.binary_find(head_index(i), nbr)
+                      : tail_.binary_find(tail_index(i), nbr);
+  }
+
   void add_vertices(vid_t to_head, vid_t to_tail) {
     max_head_id_ += to_head;
     min_tail_id_ -= to_tail;
@@ -458,6 +477,11 @@ class DeMutableCSR<VID_T, Nbr<VID_T, EDATA_T>> {
         }
       }
     }
+  }
+
+  void clear_edges() {
+    head_.clear_edges();
+    tail_.clear_edges();
   }
 
   template <typename IOADAPTOR_T>

--- a/grape/graph/de_mutable_csr.h
+++ b/grape/graph/de_mutable_csr.h
@@ -269,6 +269,12 @@ class DeMutableCSR<VID_T, Nbr<VID_T, EDATA_T>> {
     }
   }
 
+  void init_head_and_tail(vid_t min, vid_t max, bool dedup = false) {
+    min_id_ = max_head_id_ = min;
+    max_id_ = min_tail_id_ = max;
+    dedup_ = dedup;
+  }
+
   // break the operation of `add_edges` into 3 steps:
   // (1) `reserve_edges` for reserving space (capacity) of edges
   // (2) `put_edge` for inserting an edge, which can be parallel

--- a/grape/graph/de_mutable_csr.h
+++ b/grape/graph/de_mutable_csr.h
@@ -233,14 +233,17 @@ class DeMutableCSR<VID_T, Nbr<VID_T, EDATA_T>> {
   }
 
   void add_vertices(vid_t to_head, vid_t to_tail) {
-    max_head_id_ += to_head;
-    min_tail_id_ -= to_tail;
+    if (to_head != 0) {
+      max_head_id_ += to_head;
+      vid_t head_num = max_head_id_ - min_id_;
+      head_.reserve_vertices(head_num);
+    }
 
-    vid_t head_num = max_head_id_ - min_id_;
-    vid_t tail_num = max_id_ - min_tail_id_;
-
-    head_.reserve_vertices(head_num);
-    tail_.reserve_vertices(tail_num);
+    if (to_tail != 0) {
+      min_tail_id_ -= to_tail;
+      vid_t tail_num = max_id_ - min_tail_id_;
+      tail_.reserve_vertices(tail_num);
+    }
   }
 
   void add_edges(const std::vector<edge_t>& edges) {

--- a/grape/graph/de_mutable_csr.h
+++ b/grape/graph/de_mutable_csr.h
@@ -298,15 +298,13 @@ class DeMutableCSR<VID_T, Nbr<VID_T, EDATA_T>> {
   void reserve_edges_sparse(const std::map<vid_t, int>& degree_to_add) {
     std::map<vid_t, int> head_degree_to_add, tail_degree_to_add;
 
-    for(const auto &pair : degree_to_add) {
+    for (const auto &pair : degree_to_add) {
       if (in_head(pair.first)) {
         head_degree_to_add.insert(
-          std::make_pair(head_index(pair.first), pair.second)
-        );
+          std::make_pair(head_index(pair.first), pair.second));
       } else {
         tail_degree_to_add.insert(
-          std::make_pair(tail_index(pair.first), pair.second)
-        );
+          std::make_pair(tail_index(pair.first), pair.second));
       }
     }
     head_.reserve_edges_sparse(head_degree_to_add);
@@ -340,15 +338,13 @@ class DeMutableCSR<VID_T, Nbr<VID_T, EDATA_T>> {
   void sort_neighbors_sparse(const std::map<vid_t, int>& degree_to_add) {
     std::map<vid_t, int> head_degree_to_add, tail_degree_to_add;
 
-    for(const auto &pair : degree_to_add) {
+    for (const auto &pair : degree_to_add) {
       if (in_head(pair.first)) {
         head_degree_to_add.insert(
-          std::make_pair(head_index(pair.first), pair.second)
-        );
+          std::make_pair(head_index(pair.first), pair.second));
       } else {
         tail_degree_to_add.insert(
-          std::make_pair(tail_index(pair.first), pair.second)
-        );
+          std::make_pair(tail_index(pair.first), pair.second));
       }
     }
     head_.sort_neighbors_sparse(head_degree_to_add);

--- a/grape/graph/de_mutable_csr.h
+++ b/grape/graph/de_mutable_csr.h
@@ -277,11 +277,15 @@ class DeMutableCSR<VID_T, Nbr<VID_T, EDATA_T>> {
   void reserve_edges_dense(const std::vector<int>& degree_to_add) {
     // vid_t head_num = max_head_id_ - min_id_;
     // vid_t tail_num = max_id_ - min_tail_id_;
+
     auto head_begin = degree_to_add.begin() + min_id_;
     auto head_end = degree_to_add.begin() + max_head_id_;
+
     auto tail_begin = degree_to_add.begin() + min_tail_id_;
     auto tail_end = degree_to_add.begin() + max_id_;
+
     std::vector<int> head_degree_to_add(head_begin, head_end);
+    
     std::vector<int> tail_degree_to_add(max_id_ - min_tail_id_);
     std::reverse_copy(tail_begin, tail_end, 
               tail_degree_to_add.begin());
@@ -296,13 +300,17 @@ class DeMutableCSR<VID_T, Nbr<VID_T, EDATA_T>> {
 
     for(const auto &pair : degree_to_add) {
       if (in_head(pair.first)) {
-        head_degree_to_add.insert(head_index(pair.first), pair.second);
+        head_degree_to_add.insert(
+          std::make_pair(head_index(pair.first), pair.second)
+        );
       } else {
-        tail_degree_to_add.insert(tail_index(pair.first), pair.second);
+        tail_degree_to_add.insert(
+          std::make_pair(tail_index(pair.first), pair.second)
+        );
       }
     }
-    head_.reserve_edges_dense(head_degree_to_add);
-    tail_.reserve_edges_dense(tail_degree_to_add);
+    head_.reserve_edges_sparse(head_degree_to_add);
+    tail_.reserve_edges_sparse(tail_degree_to_add);
   }
 
   nbr_t* put_edge(vid_t src, const nbr_t& value) {
@@ -324,11 +332,15 @@ class DeMutableCSR<VID_T, Nbr<VID_T, EDATA_T>> {
   void sort_neighbors_dense(const std::vector<int>& degree_to_add) {
     // vid_t head_num = max_head_id_ - min_id_;
     // vid_t tail_num = max_id_ - min_tail_id_;
+
     auto head_begin = degree_to_add.begin() + min_id_;
     auto head_end = degree_to_add.begin() + max_head_id_;
+
     auto tail_begin = degree_to_add.begin() + min_tail_id_;
     auto tail_end = degree_to_add.begin() + max_id_;
+
     std::vector<int> head_degree_to_add(head_begin, head_end);
+
     std::vector<int> tail_degree_to_add(max_id_ - min_tail_id_);
     std::reverse_copy(tail_begin, tail_end, 
               tail_degree_to_add.begin());
@@ -343,15 +355,18 @@ class DeMutableCSR<VID_T, Nbr<VID_T, EDATA_T>> {
 
     for(const auto &pair : degree_to_add) {
       if (in_head(pair.first)) {
-        head_degree_to_add.insert(head_index(pair.first), pair.second);
+        head_degree_to_add.insert(
+          std::make_pair(head_index(pair.first), pair.second)
+        );
       } else {
-        tail_degree_to_add.insert(tail_index(pair.first), pair.second);
+        tail_degree_to_add.insert(
+          std::make_pair(tail_index(pair.first), pair.second)
+        );
       }
     }
     head_.sort_neighbors_sparse(head_degree_to_add);
     tail_.sort_neighbors_sparse(tail_degree_to_add);
   }
-
 
   void remove_edges(const std::vector<edge_t>& edges) {
     vid_t head_num = max_head_id_ - min_id_;

--- a/grape/graph/de_mutable_csr.h
+++ b/grape/graph/de_mutable_csr.h
@@ -274,23 +274,10 @@ class DeMutableCSR<VID_T, Nbr<VID_T, EDATA_T>> {
   // (2) `put_edge` for inserting an edge, which can be parallel
   // (3) `sort_neighbors` for cleanning up the nerghbors
 
-  void reserve_edges_dense(const std::vector<int>& degree_to_add) {
-    // vid_t head_num = max_head_id_ - min_id_;
-    // vid_t tail_num = max_id_ - min_tail_id_;
-
-    auto head_begin = degree_to_add.begin() + min_id_;
-    auto head_end = degree_to_add.begin() + max_head_id_;
-
-    auto tail_begin = degree_to_add.begin() + min_tail_id_;
-    auto tail_end = degree_to_add.begin() + max_id_;
-
-    std::vector<int> head_degree_to_add(head_begin, head_end);
-    
-    std::vector<int> tail_degree_to_add(max_id_ - min_tail_id_);
-    std::reverse_copy(tail_begin, tail_end, 
-              tail_degree_to_add.begin());
-    assert(tail_degree_to_add.size() == max_id_ - min_tail_id_);
-
+  // `degree_to_add` is indexed by the real index,
+  // and the caller is responsible for conversion
+  void reserve_edges_dense(const std::vector<int>& head_degree_to_add,
+                           const std::vector<int>& tail_degree_to_add) {
     head_.reserve_edges_dense(head_degree_to_add);
     tail_.reserve_edges_dense(tail_degree_to_add);
   }
@@ -329,23 +316,10 @@ class DeMutableCSR<VID_T, Nbr<VID_T, EDATA_T>> {
     }
   }
 
-  void sort_neighbors_dense(const std::vector<int>& degree_to_add) {
-    // vid_t head_num = max_head_id_ - min_id_;
-    // vid_t tail_num = max_id_ - min_tail_id_;
-
-    auto head_begin = degree_to_add.begin() + min_id_;
-    auto head_end = degree_to_add.begin() + max_head_id_;
-
-    auto tail_begin = degree_to_add.begin() + min_tail_id_;
-    auto tail_end = degree_to_add.begin() + max_id_;
-
-    std::vector<int> head_degree_to_add(head_begin, head_end);
-
-    std::vector<int> tail_degree_to_add(max_id_ - min_tail_id_);
-    std::reverse_copy(tail_begin, tail_end, 
-              tail_degree_to_add.begin());
-    assert(tail_degree_to_add.size() == max_id_ - min_tail_id_);
-
+  // `degree_to_add` is indexed by the real index,
+  // and the caller is responsible for conversion
+  void sort_neighbors_dense(const std::vector<int>& head_degree_to_add,
+                            const std::vector<int>& tail_degree_to_add) {
     head_.sort_neighbors_dense(head_degree_to_add);
     tail_.sort_neighbors_dense(tail_degree_to_add);
   }


### PR DESCRIPTION
## What do these changes do?

Add interfaces in DeMutableCSR:

(1) basic methods: `clear`, `find`, and `binary_find`
(2) break the operation of `add_edges` into 3 steps:
  (2.1) `reserve_edges` for reserving space (capacity) of edges
  (2.2) `put_edge` for inserting an edge, which can be parallel
  (2.3) `sort_neighbors` for cleanning up the nerghbors

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes
