### PR TITLE
[Fix bug] Fix the 'const class std::basic_string_view<char>' has no member named 'to_string' error in C++17.

### DIFF
--- a/grape/fragment/partitioner.h
+++ b/grape/fragment/partitioner.h
@@ -220,13 +220,13 @@ class SegmentedPartitioner<std::string> {
   inline fid_t GetPartitionId(const oid_t& oid) const { return o2f_.at(oid); }
 
   inline fid_t GetPartitionId(const internal_oid_t& oid) const {
-    return o2f_.at(oid.to_string());
+    return o2f_.at(std::string(oid));
   }
 
   void SetPartitionId(const oid_t& oid, fid_t fid) { o2f_[oid] = fid; }
 
   void SetPartitionId(const internal_oid_t& oid, fid_t fid) {
-    o2f_[oid.to_string()] = fid;
+    o2f_[std::string(oid)] = fid;
   }
 
   SegmentedPartitioner& operator=(const SegmentedPartitioner& other) {

--- a/grape/types.h
+++ b/grape/types.h
@@ -133,7 +133,7 @@ struct InternalOID<std::string> {
     return nonstd::string_view(val.data(), val.size());
   }
 
-  static std::string FromInternal(const type& val) { return val.to_string(); }
+  static std::string FromInternal(const type& val) { return std::string(val); }
 };
 
 }  // namespace grape


### PR DESCRIPTION
As titled.

REF:
- https://github.com/alibaba/libgrape-lite/blob/master/thirdparty/string_view/string_view.hpp#L1068
- https://en.cppreference.com/w/cpp/string/basic_string_view