### PR TITLE
Fix dangling pointer warning under g++ 12.2.0

### DIFF
--- a/grape/graph/adj_list.h
+++ b/grape/graph/adj_list.h
@@ -262,7 +262,7 @@ class FilterAdjList {
   using NbrT = Nbr<VID_T, EDATA_T>;
 
  public:
-  FilterAdjList(NbrT* b, NbrT* e, const PRED_T& pred)
+  FilterAdjList(NbrT* b, NbrT* e, PRED_T pred)
       : begin_(b), end_(e), pred_(pred) {
     while (begin_ != end_ && !pred_(*begin_)) {
       ++begin_;
@@ -363,7 +363,7 @@ class FilterAdjList {
  private:
   NbrT* begin_;
   NbrT* end_;
-  const PRED_T& pred_;
+  PRED_T pred_;
 };
 
 template <typename VID_T, typename EDATA_T, typename PRED_T>
@@ -371,7 +371,7 @@ class FilterConstAdjList {
   using NbrT = Nbr<VID_T, EDATA_T>;
 
  public:
-  FilterConstAdjList(const NbrT* b, const NbrT* e, const PRED_T& pred)
+  FilterConstAdjList(const NbrT* b, const NbrT* e, PRED_T pred)
       : begin_(b), end_(e), pred_(pred) {
     while (begin_ != end_ && !pred_(*begin_)) {
       ++begin_;
@@ -430,7 +430,7 @@ class FilterConstAdjList {
  private:
   const NbrT* begin_;
   const NbrT* end_;
-  const PRED_T& pred_;
+  PRED_T pred_;
 };
 
 /**


### PR DESCRIPTION
Compiling under g++ 12.2.0 raise an warning about dangling pointer
```
/root/libgrape-lite/grape/graph/adj_list.h:266:29: error: storing the address of local variable '<anonymous>' in '*<return-value>.grape::FilterAdjList<unsigned int, grape::E
mptyType, std::function<bool(const grape::Nbr<unsigned int, grape::EmptyType>&)> >::pred_' [-Werror=dangling-pointer=]
    266 |       : begin_(b), end_(e), pred_(pred) {
            |                             ^~~~~~~~~~~
/root/libgrape-lite/grape/fragment/mutable_edgecut_fragment.h: In member function 'grape::MutableEdgecutFragment<OID_T, VID_T, VDATA_T, EDATA_T, _load_strategy, VERTEX_MAP_T
>::fragment_adj_list_t grape::MutableEdgecutFragment<OID_T, VID_T, VDATA_T, EDATA_T, _load_strategy, VERTEX_MAP_T>::GetIncomingAdjList(const vertex_t&, grape::fid_t) [with O
ID_T = long int; VID_T = unsigned int; VDATA_T = grape::EmptyType; EDATA_T = grape::EmptyType; grape::LoadStrategy _load_strategy = grape::LoadStrategy::kOnlyOut; VERTEX_MAP
_T = grape::GlobalVertexMap<long int, unsigned int, grape::HashPartitioner<long int> >]':
/root/libgrape-lite/grape/fragment/mutable_edgecut_fragment.h:512:12: note: '<anonymous>' declared here
    512 |     return fragment_adj_list_t(
            |            ^~~~~~~~~~~~~~~~~~~~
    513 |         get_ie_begin(v), get_ie_end(v), [this, dst_fid](const nbr_t& nbr) {
            |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    514 |           return this->GetFragId(nbr.get_neighbor()) == dst_fid;
            |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    515 |         });
```

And it won't introduce any impact on performance in this move-lambda case.
Ref: https://stackoverflow.com/questions/18365532/should-i-pass-an-stdfunction-by-const-reference