### PR TITLE
Configure the selection of string-view to match with apache-arrow.

### DIFF
--- a/grape/communication/shuffle.h
+++ b/grape/communication/shuffle.h
@@ -23,8 +23,8 @@ limitations under the License.
 #include <vector>
 
 #include "grape/communication/sync_comm.h"
+#include "grape/types.h"
 #include "grape/utils/string_view_vector.h"
-#include "string_view/string_view.hpp"
 
 namespace grape {
 

--- a/grape/graph/id_indexer.h
+++ b/grape/graph/id_indexer.h
@@ -21,8 +21,8 @@ limitations under the License.
 #include <vector>
 
 #include "flat_hash_map/flat_hash_map.hpp"
+#include "grape/types.h"
 #include "grape/utils/string_view_vector.h"
-#include "string_view/string_view.hpp"
 
 namespace grape {
 

--- a/grape/serialization/in_archive.h
+++ b/grape/serialization/in_archive.h
@@ -29,8 +29,8 @@ limitations under the License.
 #include <vector>
 
 #include "flat_hash_map/flat_hash_map.hpp"
+#include "grape/types.h"
 #include "grape/utils/gcontainer.h"
-#include "string_view/string_view.hpp"
 
 namespace grape {
 

--- a/grape/serialization/out_archive.h
+++ b/grape/serialization/out_archive.h
@@ -28,8 +28,8 @@ limitations under the License.
 
 #include "flat_hash_map/flat_hash_map.hpp"
 #include "grape/serialization/in_archive.h"
+#include "grape/types.h"
 #include "grape/utils/gcontainer.h"
-#include "string_view/string_view.hpp"
 
 namespace grape {
 

--- a/grape/types.h
+++ b/grape/types.h
@@ -20,6 +20,8 @@ limitations under the License.
 #include <ostream>
 #include <type_traits>
 
+// Use the same setting with apache-arrow to avoid possible conflicts
+#define nssv_CONFIG_SELECT_STRING_VIEW nssv_STRING_VIEW_NONSTD
 #include "string_view/string_view.hpp"
 
 namespace grape {

--- a/grape/utils/string_view_vector.h
+++ b/grape/utils/string_view_vector.h
@@ -21,7 +21,7 @@ limitations under the License.
 
 #include <vector>
 
-#include "string_view/string_view.hpp"
+#include "grape/types.h"
 
 namespace grape {
 


### PR DESCRIPTION

## What do these changes do?

as titled, avoiding the conflicts in GraphScope.

## Related issue number

N/A