### PR TITLE
Correct the operator++(int) and operator--(int) behavior in VertexRange class

### DIFF
--- a/grape/utils/vertex_array.h
+++ b/grape/utils/vertex_array.h
@@ -149,7 +149,9 @@ class VertexRange {
     }
 
     DEV_HOST_INLINE iterator operator++(int) noexcept {
-      return iterator(cur_.GetValue() + 1);
+      iterator ret = *this;
+      ++*this;
+      return ret;
     }
 
     DEV_HOST_INLINE iterator& operator--() noexcept {
@@ -158,7 +160,9 @@ class VertexRange {
     }
 
     DEV_HOST_INLINE iterator operator--(int) noexcept {
-      return iterator(cur_.GetValue()--);
+      iterator ret = *this;
+      --*this;
+      return ret;
     }
 
     DEV_HOST_INLINE iterator operator+(size_t offset) const noexcept {


### PR DESCRIPTION

<!--
Thanks for your contribution! please review https://github.com/alibaba/libgrape-lite/blob/master/CONTRIBUTING.rst before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Related issue in GraphScope: https://github.com/alibaba/GraphScope/discussions/2735
