### PR TITLE
Fixes the behaviour of gcontainer's __destruct_at_end.

### DIFF
--- a/grape/utils/gcontainer.h
+++ b/grape/utils/gcontainer.h
@@ -174,7 +174,6 @@ class Array {
     while (__new_last != __soon_to_be_end) {
       __alloc_traits::destroy(__alloc(), --__soon_to_be_end);
     }
-    this->__base.__end_ = __new_last;
   }
 
   inline void __destruct_at_end(pointer __new_last, pointer __end) {


### PR DESCRIPTION
The function `__destruct_at_end` shouldn't update __begin/__end otherwise an incorrect `size()` will be pass to deallocate() where some allocator may fail to free memory as expected.

