### PR TITLE
Fixes the missing of copy ctor for bitset

### DIFF
--- a/grape/utils/bitset.h
+++ b/grape/utils/bitset.h
@@ -25,6 +25,7 @@ limitations under the License.
 #include "thread_pool.h"
 
 #define WORD_SIZE(n) (((n) + 63ul) >> 6)
+#define BYTE_SIZE(n) (((n) + 63ul) >> 3)
 
 #define WORD_INDEX(i) ((i) >> 6)
 #define BIT_OFFSET(i) ((i) &0x3f)
@@ -44,6 +45,12 @@ class Bitset : public Allocator<uint64_t> {
     size_in_words_ = WORD_SIZE(size_);
     data_ = this->allocate(size_in_words_);
     clear();
+  }
+  Bitset(const Bitset& other)
+      : size_(other.size_),
+        size_in_words_(other.size_in_words_) {
+    data_ = this->allocate(size_in_words_);
+    memcpy(data_, other.data_, BYTE_SIZE(size_));
   }
   Bitset(Bitset&& other)
       : data_(other.data_),
@@ -348,6 +355,7 @@ class RefBitset {
 };
 
 #undef WORD_SIZE
+#undef BYTE_SIZE
 #undef WORD_INDEX
 #undef BIT_OFFSET
 #undef ROUND_UP


### PR DESCRIPTION
A move ctor was added to `Bitset` since #149, since then, it was no longer trivial-copy-constructible.

When using it in contexts like

```
std::vector<grape::DenseVertexSet<typename FRAG_T::inner_vertices_t> > curr_inner_updated, next_inner_updated;
auto v_label_num = valid_vertexes.size();
    curr_inner_updated.resize(v_label_num);
    next_inner_updated.resize(v_label_num);
```

it fails to compile under GCC-11.