### PR TITLE
Fix missing assignment operator for Bitset

### DIFF
--- a/grape/utils/bitset.h
+++ b/grape/utils/bitset.h
@@ -47,8 +47,7 @@ class Bitset : public Allocator<uint64_t> {
     clear();
   }
   Bitset(const Bitset& other)
-      : size_(other.size_),
-        size_in_words_(other.size_in_words_) {
+      : size_(other.size_), size_in_words_(other.size_in_words_) {
     data_ = this->allocate(size_in_words_);
     memcpy(data_, other.data_, BYTE_SIZE(size_));
   }
@@ -64,6 +63,34 @@ class Bitset : public Allocator<uint64_t> {
     if (data_ != NULL) {
       this->deallocate(data_, size_in_words_);
     }
+  }
+
+  Bitset& operator=(const Bitset& other) {
+    if (this == &other) {
+      return *this;
+    }
+
+    size_ = other.size_;
+    size_in_words_ = other.size_in_words_;
+
+    data_ = this->allocate(size_in_words_);
+    memcpy(data_, other.data_, BYTE_SIZE(size_));
+    return *this;
+  }
+
+  Bitset& operator=(Bitset&& other) {
+    if (this == &other) {
+      return *this;
+    }
+
+    data_ = other.data_;
+    size_ = other.size_;
+    size_in_words_ = other.size_in_words_;
+
+    other.data_ = NULL;
+    other.size_ = 0;
+    other.size_in_words_ = 0;
+    return *this;
   }
 
   void init(size_t size) {


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/libgrape-lite/blob/master/CONTRIBUTING.rst before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
In PR #154 and #149, copy and move ctor for Bitset are added, however, the assignment operator is not added, and there will be compile error, see follow.
<img width="1716" alt="f2" src="https://github.com/alibaba/libgrape-lite/assets/9260628/762ef190-3974-43ff-bd6e-393f04f222c8">
<img width="1715" alt="f3" src="https://github.com/alibaba/libgrape-lite/assets/9260628/69398d1f-fecf-416f-806c-7f32d0336589">


