### PR TITLE
Fix Bitset's core dump when copying from an empty Bitset

### DIFF
--- a/grape/utils/bitset.h
+++ b/grape/utils/bitset.h
@@ -48,8 +48,12 @@ class Bitset : public Allocator<uint64_t> {
   }
   Bitset(const Bitset& other)
       : size_(other.size_), size_in_words_(other.size_in_words_) {
-    data_ = this->allocate(size_in_words_);
-    memcpy(data_, other.data_, BYTE_SIZE(size_));
+    if (size_ == 0) {
+      data_ = NULL;
+    } else {
+      data_ = this->allocate(size_in_words_);
+      memcpy(data_, other.data_, BYTE_SIZE(size_));
+    }
   }
   Bitset(Bitset&& other)
       : data_(other.data_),
@@ -73,8 +77,12 @@ class Bitset : public Allocator<uint64_t> {
     size_ = other.size_;
     size_in_words_ = other.size_in_words_;
 
-    data_ = this->allocate(size_in_words_);
-    memcpy(data_, other.data_, BYTE_SIZE(size_));
+    if (size_ == 0) {
+      data_ = NULL;
+    } else {
+      data_ = this->allocate(size_in_words_);
+      memcpy(data_, other.data_, BYTE_SIZE(size_));
+    }
     return *this;
   }
 

--- a/grape/utils/bitset.h
+++ b/grape/utils/bitset.h
@@ -74,6 +74,10 @@ class Bitset : public Allocator<uint64_t> {
       return *this;
     }
 
+    if (data_ != NULL) {
+      this->deallocate(data_, size_in_words_);
+    }
+
     size_ = other.size_;
     size_in_words_ = other.size_in_words_;
 
@@ -89,6 +93,10 @@ class Bitset : public Allocator<uint64_t> {
   Bitset& operator=(Bitset&& other) {
     if (this == &other) {
       return *this;
+    }
+
+    if (data_ != NULL) {
+      this->deallocate(data_, size_in_words_);
     }
 
     data_ = other.data_;


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/libgrape-lite/blob/master/CONTRIBUTING.rst before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
The Bitset can be constructed with size == 0, and when another Bitset copies from the empty Bitset, there will be core dump as the memcpy()

<img width="1714" alt="f1" src="https://github.com/alibaba/libgrape-lite/assets/9260628/cb645526-8d90-4a6e-b2c6-3473f8523270">

