### PR TITLE
Add necessary headers and make `get_available_memory` inline

### DIFF
--- a/grape/parallel/thread_local_message_buffer.h
+++ b/grape/parallel/thread_local_message_buffer.h
@@ -22,6 +22,7 @@ limitations under the License.
 
 #include "grape/graph/adj_list.h"
 #include "grape/serialization/in_archive.h"
+#include "grape/util.h"
 
 namespace grape {
 

--- a/grape/util.h
+++ b/grape/util.h
@@ -27,7 +27,9 @@ limitations under the License.
 #include <sys/time.h>
 
 #include <algorithm>
+#include <cassert>
 #include <fstream>
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>
@@ -180,7 +182,7 @@ inline std::map<std::string, size_t> parse_meminfo() {
   return ret;
 }
 
-size_t get_available_memory() {
+inline size_t get_available_memory() {
   auto meminfo = parse_meminfo();
 #ifdef USE_HUGEPAGES
   return meminfo.at("HugePages_Free") * meminfo.at("Hugepagesize");

--- a/grape/utils/message_buffer_pool.h
+++ b/grape/utils/message_buffer_pool.h
@@ -19,6 +19,7 @@ limitations under the License.
 #include <deque>
 
 #include "grape/config.h"
+#include "grape/util.h"
 #include "grape/utils/concurrent_queue.h"
 
 namespace grape {


### PR DESCRIPTION
Errors were encountered during the building with GraphScope Flex with latest libgrape-lite.