### PR TITLE
fix: Fix warnings of C++ 17 compiler

### DIFF
--- a/examples/analytical_apps/bc/staged_bc_bfs.h
+++ b/examples/analytical_apps/bc/staged_bc_bfs.h
@@ -150,8 +150,8 @@ class StagedBCBFS : public ParallelAppBase<FRAG_T, BCContext<FRAG_T>,
         });
 
     // sync messages to other workers
-    ForEach(ctx.curr_inner_updated, [next_depth, &frag, &ctx, &channels](
-                                        int tid, vertex_t v) {
+    ForEach(ctx.curr_inner_updated, [next_depth, &frag, &ctx](int tid,
+                                                              vertex_t v) {
       auto oes = frag.GetOutgoingAdjList(v);
       double pn = ctx.path_num[v];
       for (auto& e : oes) {

--- a/examples/analytical_apps/core_decomposition/core_decomposition.h
+++ b/examples/analytical_apps/core_decomposition/core_decomposition.h
@@ -75,7 +75,7 @@ class CoreDecomposition
           });
           ctx.curr_inner_updated.ParallelClear(GetThreadPool());
 
-          ForEach(ctx.next_inner_updated, [&frag, &ctx](int tid, vertex_t v) {
+          ForEach(ctx.next_inner_updated, [&ctx](int tid, vertex_t v) {
             if (ctx.partial_result[v] > ctx.level) {
               int new_core = ctx.partial_result[v] - ctx.reduced_degrees[v];
               ctx.reduced_degrees[v] = 0;
@@ -115,7 +115,7 @@ class CoreDecomposition
         });
         ctx.curr_inner_updated.ParallelClear(GetThreadPool());
 
-        ForEach(ctx.next_inner_updated, [&frag, &ctx](int tid, vertex_t v) {
+        ForEach(ctx.next_inner_updated, [&ctx](int tid, vertex_t v) {
           if (ctx.partial_result[v] > ctx.level) {
             int new_core = ctx.partial_result[v] - ctx.reduced_degrees[v];
             ctx.reduced_degrees[v] = 0;
@@ -149,7 +149,7 @@ class CoreDecomposition
           ctx.next_inner_updated.Insert(v);
         });
 
-    ForEach(ctx.next_inner_updated, [&frag, &ctx](int tid, vertex_t v) {
+    ForEach(ctx.next_inner_updated, [&ctx](int tid, vertex_t v) {
       if (ctx.partial_result[v] > ctx.level) {
         int new_core = ctx.partial_result[v] - ctx.reduced_degrees[v];
         ctx.reduced_degrees[v] = 0;
@@ -219,7 +219,7 @@ class CoreDecomposition
       });
       ctx.curr_inner_updated.ParallelClear(GetThreadPool());
 
-      ForEach(ctx.next_inner_updated, [&frag, &ctx](int tid, vertex_t v) {
+      ForEach(ctx.next_inner_updated, [&ctx](int tid, vertex_t v) {
         if (ctx.partial_result[v] > ctx.level) {
           int new_core = ctx.partial_result[v] - ctx.reduced_degrees[v];
           ctx.reduced_degrees[v] = 0;

--- a/examples/analytical_apps/kcore/kcore.h
+++ b/examples/analytical_apps/kcore/kcore.h
@@ -89,20 +89,19 @@ class KCore : public ParallelAppBase<FRAG_T, KCoreContext<FRAG_T>,
         });
 
     ctx.next_inner_updated.ParallelClear(GetThreadPool());
-    ForEach(ctx.curr_inner_updated,
-            [&frag, &ctx, &channels](int tid, vertex_t v) {
-              if (ctx.partial_result[v] >= ctx.k) {
-                ctx.partial_result[v] -= ctx.reduced_degrees[v];
-                ctx.reduced_degrees[v] = 0;
+    ForEach(ctx.curr_inner_updated, [&ctx](int tid, vertex_t v) {
+      if (ctx.partial_result[v] >= ctx.k) {
+        ctx.partial_result[v] -= ctx.reduced_degrees[v];
+        ctx.reduced_degrees[v] = 0;
 
-                if (ctx.partial_result[v] < ctx.k) {
-                  ctx.next_inner_updated.Insert(v);
-                }
-              } else {
-                ctx.partial_result[v] -= ctx.reduced_degrees[v];
-                ctx.reduced_degrees[v] = 0;
-              }
-            });
+        if (ctx.partial_result[v] < ctx.k) {
+          ctx.next_inner_updated.Insert(v);
+        }
+      } else {
+        ctx.partial_result[v] -= ctx.reduced_degrees[v];
+        ctx.reduced_degrees[v] = 0;
+      }
+    });
 
     ctx.curr_inner_updated.ParallelClear(GetThreadPool());
     ForEach(ctx.next_inner_updated, [&frag, &ctx](int tid, vertex_t v) {

--- a/examples/analytical_apps/kcore/kcore_context.h
+++ b/examples/analytical_apps/kcore/kcore_context.h
@@ -41,7 +41,8 @@ class KCoreContext : public VertexDataContext<FRAG_T, int> {
       }
     }
 
-    LOG(INFO) << "[frag-" << frag.fid() << "] " << "KCore: " << num;
+    LOG(INFO) << "[frag-" << frag.fid() << "] "
+              << "KCore: " << num;
   }
 
   int k;

--- a/grape/cuda/utils/cuda_utils.h
+++ b/grape/cuda/utils/cuda_utils.h
@@ -170,7 +170,7 @@ size_t get_rss(bool include_shared_memory) {
   if (include_shared_memory) {
     return (size_t) rss * (size_t) sysconf(_SC_PAGESIZE);
   } else {
-    return (size_t) (rss - shared_rss) * (size_t) sysconf(_SC_PAGESIZE);
+    return (size_t)(rss - shared_rss) * (size_t) sysconf(_SC_PAGESIZE);
   }
 #else
   /* Unknown OS ----------------------------------------------- */

--- a/grape/cuda/utils/work_source.h
+++ b/grape/cuda/utils/work_source.h
@@ -24,7 +24,7 @@ struct WorkSourceRange {
  public:
   DEV_HOST WorkSourceRange(T start, size_t size) : start_(start), size_(size) {}
 
-  DEV_HOST_INLINE T GetWork(size_t i) const { return (T) (start_ + i); }
+  DEV_HOST_INLINE T GetWork(size_t i) const { return (T)(start_ + i); }
 
   DEV_HOST_INLINE size_t size() const { return size_; }
 

--- a/grape/parallel/thread_local_message_buffer_opt.h
+++ b/grape/parallel/thread_local_message_buffer_opt.h
@@ -65,7 +65,7 @@ class ThreadLocalMessageBufferOpt {
     to_send_.resize(fnum_);
 
     for (auto& arc : to_send_) {
-      arc.init(std::move(pool_->take_default()));
+      arc.init(pool_->take_default());
     }
 
     sent_size_ = 0;

--- a/grape/types.h
+++ b/grape/types.h
@@ -138,6 +138,14 @@ struct InternalOID<std::string> {
   static std::string FromInternal(const type& val) { return std::string(val); }
 };
 
+#ifdef __cpp_lib_is_invocable
+template <class T, typename... Args>
+using result_of_t = std::invoke_result_t<T, Args...>;
+#else
+template <class T, typename... Args>
+using result_of_t = typename std::result_of<T(Args...)>::type;
+#endif
+
 }  // namespace grape
 
 #endif  // GRAPE_TYPES_H_

--- a/grape/utils/concurrent_queue.h
+++ b/grape/utils/concurrent_queue.h
@@ -156,7 +156,8 @@ class SpinLock {
  public:
   void lock() {
     while (locked.test_and_set(std::memory_order_acquire)) {
-      {}
+      {
+      }
     }
   }
 

--- a/grape/utils/thread_pool.h
+++ b/grape/utils/thread_pool.h
@@ -41,6 +41,7 @@
 #include <glog/logging.h>
 
 #include "grape/parallel/parallel_engine_spec.h"
+#include "grape/types.h"
 
 #if __linux__
 #ifndef _GNU_SOURCE
@@ -58,7 +59,7 @@ class ThreadPool {
 
   template <class F, class... Args>
   auto enqueue(F&& f, Args&&... args)
-      -> std::future<typename std::result_of<F(Args...)>::type>;
+      -> std::future<grape::result_of_t<F, Args...>>;
   inline int GetThreadNum() { return thread_num_; }
   void WaitEnd(std::vector<std::future<void>>& results);
   ~ThreadPool();

--- a/grape/worker/worker.h
+++ b/grape/worker/worker.h
@@ -106,8 +106,6 @@ class Worker {
     context_->Init(messages_, std::forward<Args>(args)...);
     processMutation();
 
-    int round = 0;
-
     messages_.Start();
 
     messages_.StartARound();
@@ -126,7 +124,6 @@ class Worker {
 
     while (!messages_.ToTerminate()) {
       t = GetCurrentTime();
-      round++;
       messages_.StartARound();
 
       runIncEval();


### PR DESCRIPTION
1. fix `std::result_of` is deprecated in c++ 17 https://en.cppreference.com/w/cpp/types/result_of
2. fix unused variables.