### PR TITLE
Fix installation of pthash.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -298,6 +298,13 @@ install(DIRECTORY ${PROJECT_SOURCE_DIR}/thirdparty/flat_hash_map
         PATTERN "*.hpp"
 )
 
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/thirdparty/pthash/
+        DESTINATION include/pthash
+        FILES_MATCHING
+        PATTERN "*.h"
+        PATTERN "*.hpp"
+)
+
 if (WITH_CUDA)
   install(DIRECTORY ${PROJECT_SOURCE_DIR}/thirdparty/cuda_hashmap
           DESTINATION include/cuda_hashmap


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/libgrape-lite/blob/master/CONTRIBUTING.rst before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

As tittled.

Example:
test.cc
```
#include <memory>
#include <set>
#include <string.h>
#include <string_view>
#include "grape/utils/pthash_utils/single_phf_view.h"

using namespace grape;

int main() {
  return 0;
}
```

CMakelists.txt
```
cmake_minimum_required(VERSION 3.26)
project(test1)
add_executable(test test.cc)
find_package(libgrapelite REQUIRED)
target_include_directories(test PUBLIC ${LIBGRAPELITE_INCLUDE_DIRS})
```

Shell
```
cmake .
make
```

It triggers an error:
![image](https://github.com/user-attachments/assets/18ae2f96-9e39-4dc2-8459-b70ce616b436)

The reason of this fault is that currently grape will not install the pthash header to /usr/local/include.
