### PR TITLE
Fix message manager core dump when data is small

### DIFF
--- a/grape/parallel/batch_shuffle_message_manager.h
+++ b/grape/parallel/batch_shuffle_message_manager.h
@@ -411,10 +411,12 @@ class BatchShuffleMessageManager : public MessageManagerBase {
           }
           fid_t src_fid = (fid_ + fnum_ - got) % fnum_;
           auto range = frag.OuterVertices(src_fid);
-          sync_comm::irecv_buffer<char>(
-              reinterpret_cast<char*>(&data[*range.begin()]),
-              range.size() * sizeof(DATA_T), comm_spec_.FragToWorker(src_fid),
-              0, comm_, &recv_reqs_[req_offsets[src_fid]]);
+          if (range.size() != 0) {
+            sync_comm::irecv_buffer<char>(
+                reinterpret_cast<char*>(&data[*range.begin()]),
+                range.size() * sizeof(DATA_T), comm_spec_.FragToWorker(src_fid),
+                0, comm_, &recv_reqs_[req_offsets[src_fid]]);
+          }
         }
       });
     }


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/libgrape-lite/blob/master/CONTRIBUTING.rst before opening an issue.
-->

## What do these changes do?
When test PageRank with small data using misc/app_test.sh, run_app is core dumped, the reason is that the vector 'data' is out-of-range `reinterpret_cast<char*>(&data[*range.begin()]),` in [code](https://github.com/alibaba/libgrape-lite/blob/e7c4465811d558ebccea746ca4d87f398ebf3cb2/grape/parallel/batch_shuffle_message_manager.h#L415) 

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

<img width="767" alt="f1" src="https://github.com/user-attachments/assets/1c0a8071-3db5-4599-8d52-99c82434cbcf" />

