### PR TITLE
Fix sync buffer crash

### DIFF
--- a/grape/parallel/sync_buffer.h
+++ b/grape/parallel/sync_buffer.h
@@ -62,7 +62,8 @@ class SyncBuffer : public ISyncBuffer {
   bool updated(size_t begin, size_t length) const override {
     auto iter = range_.begin() + begin;
     while (length-- && iter != range_.end()) {
-      if (updated_[*iter++]) {
+      if (updated_[*iter]) {
+        iter++;
         return true;
       }
     }


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/libgrape-lite/blob/master/CONTRIBUTING.rst before opening an issue.
-->

## What do these changes do?
When test with mutable_fragment_tests, the process crashed when data is small. It seems the overloading of operator++(int) in [code](https://github.com/alibaba/libgrape-lite/blob/e7c4465811d558ebccea746ca4d87f398ebf3cb2/grape/utils/vertex_array.h#L302) doesn't return the old value, but return the new value, which is not the normal implementation.
` 
iterator operator++(int) noexcept {

      VID_T new_value = cur_.GetValue() + 1;
      if (new_value == head_end_) {
        new_value = tail_begin_;
      }
      return iterator(new_value, head_end_, tail_begin_);
    }
`

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

<img width="650" alt="f3" src="https://github.com/user-attachments/assets/7fd339d9-bcd2-46f3-9621-9ac4afe47043" />

