### PR TITLE
[FEATURE-180] Support building with glog 0.7+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,11 +167,17 @@ set(CMAKE_THREAD_PREFER_PTHREAD ON)
 find_package(Threads REQUIRED)
 
 # find glog---------------------------------------------------------------------
-include("cmake/FindGlog.cmake")
-if (NOT GLOG_FOUND)
-  message(FATAL_ERROR "glog not found, please install the glog library")
+find_package(glog 0.7.0 QUIET)
+if (glog_FOUND)
+  set(GLOG_LIBRARIES glog::glog)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
 else ()
-  include_directories(SYSTEM ${GLOG_INCLUDE_DIRS})
+  include("cmake/FindGlog.cmake")
+  if (NOT GLOG_FOUND)
+    message(FATAL_ERROR "glog not found, please install the glog library")
+  else ()
+    include_directories(SYSTEM ${GLOG_INCLUDE_DIRS})
+  endif ()
 endif ()
 
 # find gflags-------------------------------------------------------------------

--- a/grape/io/local_io_adaptor.cc
+++ b/grape/io/local_io_adaptor.cc
@@ -16,6 +16,7 @@ limitations under the License.
 #include "grape/io/local_io_adaptor.h"
 
 #include <sys/stat.h>
+#include <unistd.h>
 
 #include <string>
 

--- a/grape/util.h
+++ b/grape/util.h
@@ -26,6 +26,7 @@ limitations under the License.
 #include <stdio.h>
 #include <sys/stat.h>
 #include <sys/time.h>
+#include <unistd.h>
 
 #include <algorithm>
 #include <cassert>

--- a/libgrapelite-config.in.cmake
+++ b/libgrapelite-config.in.cmake
@@ -6,6 +6,10 @@
 #  LIBGRAPELITE_INCLUDE_DIRS        - include directories for libgrape-lite
 #  LIBGRAPELITE_LIBRARIES           - libraries to link against
 
+if(@glog_FOUND@)
+    find_package(glog REQUIRED)
+endif()
+
 set(LIBGRAPELITE_HOME "${CMAKE_CURRENT_LIST_DIR}/../../..")
 include("${CMAKE_CURRENT_LIST_DIR}/libgrapelite-targets.cmake")
 


### PR DESCRIPTION
## What do these changes do?

This PR allows building with glog >= 0.7. Tested to work with newer glog 0.7.1 and ng-log 0.8.2. And still worked with glog 0.6.0.

I've tried to keep CMake 2.8 compatibility but haven't attempted a build with older CMake.

I only used the glog-config.cmake for 0.7.0+ since I can't guarantee older CMake files work and it allows simplifying the C++14 handling.

## Related issue number

Fixes #180
